### PR TITLE
fix localName assignement

### DIFF
--- a/ios/Classes/FlutterBlePeripheralManager.swift
+++ b/ios/Classes/FlutterBlePeripheralManager.swift
@@ -51,7 +51,7 @@ class FlutterBlePeripheralManager : NSObject {
         }
         
         if (advertiseData.localName != nil) {
-            dataToBeAdvertised[CBAdvertisementDataLocalNameKey] = [advertiseData.localName]
+            dataToBeAdvertised[CBAdvertisementDataLocalNameKey] = advertiseData.localName
         }
         
         peripheralManager.startAdvertising(dataToBeAdvertised)


### PR DESCRIPTION
The value for CBAdvertisementDataLocalNameKey is an NSString, not an array. 