### PR TITLE
:fix: prevent crash when requesting turning Bluetooth on

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
@@ -138,7 +138,11 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
     private fun enableBluetooth(call: MethodCall, result: MethodChannel.Result) {
         if (activityBinding != null) {
             val isEnabled = flutterBlePeripheralManager!!.checkAndEnableBluetooth(call.arguments as Boolean, result, activityBinding!!)
-            result.success(isEnabled)
+            // if the bluetooth is already enabled, respond immediately
+            // If not, Activity Result will respond later
+            if (isEnabled) {
+                result.success(true)
+            }
         } else {
             result.error("No activity", "FlutterBlePeripheral is not correctly initialized", "null")
         }
@@ -372,21 +376,45 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
         binding.addActivityResultListener { requestCode, resultCode, _ ->
             when (requestCode) {
                 FlutterBlePeripheralManager.REQUEST_ENABLE_BT -> {
-                    if (flutterBlePeripheralManager?.pendingResultForActivityResult != null) {
-                        startStopCall = null
-                        flutterBlePeripheralManager!!.pendingResultForActivityResult!!.success(resultCode == Activity.RESULT_OK)
-                    } else if (flutterBlePeripheralManager?.pendingResultForPermissionResult != null) {
-                        if (resultCode == Activity.RESULT_OK) {
-                            if (startStopCall != null) {
-                                onMethodCall(startStopCall!!, flutterBlePeripheralManager!!.pendingResultForPermissionResult!!)
-                                startStopCall = null
-                                flutterBlePeripheralManager?.pendingResultForPermissionResult = null
-                            }
-                        } else {
-                            flutterBlePeripheralManager?.pendingResultForPermissionResult?.success(State.TurnedOff.ordinal)
+                    try {
+                        // Handle direct Bluetooth activation request (priority 1)
+                        if (flutterBlePeripheralManager?.pendingResultForActivityResult != null) {
+                            flutterBlePeripheralManager!!.pendingResultForActivityResult!!.success(resultCode == Activity.RESULT_OK)
+                            flutterBlePeripheralManager!!.pendingResultForActivityResult = null
                         }
+                        // Handle Bluetooth activation request during permission check (priority 2)
+                        else if (flutterBlePeripheralManager?.pendingResultForPermissionResult != null) {
+                            val manager = flutterBlePeripheralManager!!
+                            if (resultCode == Activity.RESULT_OK) {
+                                // Execute delayed method call when Bluetooth activation succeeds
+                                if (startStopCall != null) {
+                                    onMethodCall(startStopCall!!, manager.pendingResultForPermissionResult!!)
+                                    startStopCall = null
+                                } else {
+                                    // Success response for simple Bluetooth activation request
+                                    manager.pendingResultForPermissionResult!!.success(true)
+                                }
+                            } else {
+                                // When user denies Bluetooth activation
+                                manager.pendingResultForPermissionResult!!.success(false)
+                            }
+                            manager.pendingResultForPermissionResult = null
+                        }
+                    } catch (e: Exception) {
+                        Log.e(tag, "Error handling Bluetooth enable result: ${e.message}")
+                        // In case of any exception, ensure all pending results are handled.
+                        try {
+                            flutterBlePeripheralManager?.pendingResultForActivityResult?.success(false)
+                        } catch (ignored: Exception) {}
+                        try {
+                            flutterBlePeripheralManager?.pendingResultForPermissionResult?.success(false)
+                        } catch (ignored: Exception) {}
+
+                        // Clear all pending results
+                        flutterBlePeripheralManager?.pendingResultForActivityResult = null
+                        flutterBlePeripheralManager?.pendingResultForPermissionResult = null
+                        startStopCall = null
                     }
-                    flutterBlePeripheralManager?.pendingResultForActivityResult = null
                     return@addActivityResultListener true
                 }
                 else -> return@addActivityResultListener false


### PR DESCRIPTION
I'm using this package for Bluetooth feature.

I found my app crashes when when the Bluetooth is turned off.
inside the method onAttachedToActivity, Bluetooth turning on request is performed multiple times and once user select whatever allow or deny, app stops.

Changes:
- Prevent returning result multiple times (before changing, enableBluetooth and ActivityResultListener can return value at the same time and it causes crash)
- prevent unintended crash and safe null check inside onAttachedToActivity.