### PR TITLE
fix: read advertise byte payloads without casting to ByteArray

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:lint/analysis_options_package.yaml

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
@@ -325,6 +325,46 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
         }
     }
 
+    /**
+     * Reads a byte payload sent from Dart.
+     *
+     * The standard method codec only keeps a typed byte array for a `Uint8List`;
+     * a `List<int>` arrives as a list of boxed ints, so both have to be accepted.
+     */
+    private fun readBytes(value: Any?): ByteArray? = when (value) {
+        null -> null
+        is ByteArray -> value
+        is List<*> -> ByteArray(value.size) { (value[it] as Number).toByte() }
+        else -> throw IllegalArgumentException("Expected a byte payload, got $value")
+    }
+
+    /** Adds the manufacturer data under [prefix] to [builder]. */
+    private fun addManufacturerData(builder: AdvertiseData.Builder, arguments: Map<*, *>, prefix: String = "") {
+        readBytes(arguments["${prefix}manufacturerData"])?.let { bytes ->
+            val id = (arguments["${prefix}manufacturerId"] as Number?)?.toInt()
+                    ?: throw IllegalArgumentException("${prefix}manufacturerData needs a ${prefix}manufacturerId")
+            builder.addManufacturerData(id, bytes)
+        }
+    }
+
+    /** Adds the service data under [prefix] to [builder]. */
+    private fun addServiceData(builder: AdvertiseData.Builder, arguments: Map<*, *>, prefix: String = "") {
+        readBytes(arguments["${prefix}serviceData"])?.let { bytes ->
+            val uuid = arguments["${prefix}serviceDataUuid"] as String?
+                    ?: throw IllegalArgumentException("${prefix}serviceData needs a ${prefix}serviceDataUuid")
+            builder.addServiceData(ParcelUuid(parseServiceUuid(uuid)), bytes)
+        }
+    }
+
+    /** Whether Dart sent anything worth putting in the advertisement under [prefix]. */
+    private fun hasAdvertiseData(arguments: Map<*, *>, prefix: String): Boolean =
+            arguments["${prefix}manufacturerData"] != null ||
+                    arguments["${prefix}serviceData"] != null ||
+                    arguments["${prefix}serviceUuid"] != null ||
+                    !(arguments["${prefix}serviceUuids"] as List<*>?).isNullOrEmpty() ||
+                    arguments["${prefix}serviceSolicitationUuid"] != null ||
+                    arguments["${prefix}includeDeviceName"] == true
+
     private fun startPeripheral(call: MethodCall, result: MethodChannel.Result) {
 
         if (call.arguments !is Map<*, *>) {
@@ -335,11 +375,11 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
 
         // First build main advertise data.
         val advertiseData: AdvertiseData.Builder = AdvertiseData.Builder()
-        (arguments["manufacturerData"] as ArrayList<*>?)?.let { list -> advertiseData.addManufacturerData((arguments["manufacturerId"] as Int), list.map { (it as Int).toByte() }.toByteArray()) }
-        (arguments["serviceData"] as ByteArray?)?.let { advertiseData.addServiceData(ParcelUuid(UUID.fromString(arguments["serviceDataUuid"] as String)), it) }
+        addManufacturerData(advertiseData, arguments)
+        addServiceData(advertiseData, arguments)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
             (arguments["serviceSolicitationUuid"] as String?)?.let { advertiseData.addServiceSolicitationUuid(
-                    ParcelUuid(UUID.fromString(it))) }
+                    ParcelUuid(parseServiceUuid(it))) }
 
         addServiceUuids(advertiseData, arguments)
         //TODO: addTransportDiscoveryData
@@ -350,13 +390,13 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
 
         // Build advertise response data if provided
         var advertiseResponseData: AdvertiseData.Builder? = null
-        if ((arguments["responsemanufacturerData"] as ByteArray?) != null || (arguments["responseserviceDataUuid"] as ByteArray?) != null || (arguments["responseserviceUuid"] as String?) != null) {
+        if (hasAdvertiseData(arguments, "response")) {
             advertiseResponseData = AdvertiseData.Builder()
-            (arguments["responsemanufacturerData"] as ByteArray?)?.let { advertiseResponseData.addManufacturerData((arguments["responsemanufacturerId"] as Int), it) }
-            (arguments["responseserviceData"] as ByteArray?)?.let { advertiseResponseData.addServiceData(ParcelUuid(UUID.fromString(arguments["responseserviceDataUuid"] as String)), it) }
+            addManufacturerData(advertiseResponseData, arguments, "response")
+            addServiceData(advertiseResponseData, arguments, "response")
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
                 (arguments["responseserviceSolicitationUuid"] as String?)?.let { advertiseResponseData.addServiceSolicitationUuid(
-                        ParcelUuid(UUID.fromString(it))) }
+                        ParcelUuid(parseServiceUuid(it))) }
 
             addServiceUuids(advertiseResponseData, arguments, "response")
             //TODO: addTransportDiscoveryData
@@ -383,26 +423,16 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
 
             var periodicAdvertiseData: AdvertiseData.Builder? = null
             var periodicAdvertiseDataSettings: PeriodicAdvertisingParameters.Builder? = null
-            if ((arguments["periodicmanufacturerData"] as ByteArray?) != null || (arguments["periodicServiceDataUuid"] as ByteArray?) != null || (arguments["periodicServiceUuid"] as String?) != null) {
+            if (hasAdvertiseData(arguments, "periodic")) {
                 periodicAdvertiseData = AdvertiseData.Builder()
                 periodicAdvertiseDataSettings = PeriodicAdvertisingParameters.Builder()
 
-                (arguments["periodicmanufacturerData"] as ByteArray?)?.let {
-                    periodicAdvertiseData.addManufacturerData(
-                            (arguments["periodicManufacturerId"] as Int),
-                            it
-                    )
-                }
-                (arguments["periodicserviceData"] as ByteArray?)?.let {
-                    periodicAdvertiseData.addServiceData(
-                            ParcelUuid(UUID.fromString(arguments["periodicserviceDataUuid"] as String)),
-                            it
-                    )
-                }
+                addManufacturerData(periodicAdvertiseData, arguments, "periodic")
+                addServiceData(periodicAdvertiseData, arguments, "periodic")
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
                     (arguments["periodicserviceSolicitationUuid"] as String?)?.let {
                         periodicAdvertiseData.addServiceSolicitationUuid(
-                                ParcelUuid(UUID.fromString(it))
+                                ParcelUuid(parseServiceUuid(it))
                         )
                     }
 

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:lint/analysis_options.yaml

--- a/test/flutter_ble_peripheral_test.dart
+++ b/test/flutter_ble_peripheral_test.dart
@@ -93,6 +93,33 @@ void main() {
       expect(arguments['serviceUuid'], isNull);
     });
 
+    // The native side reads these under a response prefix and builds a separate
+    // AdvertiseData for the scan response.
+    test('prefixes the response data with response', () async {
+      await blePeripheral.start(
+        advertiseData: AdvertiseData(serviceUuid: 'abcd'),
+        advertiseResponseData: AdvertiseData(
+          serviceUuid: 'ef01',
+          manufacturerId: 1234,
+          manufacturerData: Uint8List.fromList([1, 2, 3]),
+          serviceDataUuid: 'FEAA',
+          serviceData: const [4, 5],
+          includeDeviceName: true,
+        ),
+      );
+
+      final arguments = argumentsOf(calls.single);
+      expect(arguments['responseserviceUuid'], 'ef01');
+      expect(arguments['responsemanufacturerId'], 1234);
+      expect(arguments['responsemanufacturerData'], const [1, 2, 3]);
+      expect(arguments['responseserviceDataUuid'], 'FEAA');
+      expect(arguments['responseserviceData'], const [4, 5]);
+      expect(arguments['responseincludeDeviceName'], true);
+      // The primary data must not be overwritten by the response data.
+      expect(arguments['serviceUuid'], 'abcd');
+      expect(arguments['manufacturerData'], isNull);
+    });
+
     test('honours explicit advertise settings', () async {
       await blePeripheral.start(
         advertiseData: AdvertiseData(),


### PR DESCRIPTION
## Description

The response and periodic advertise blocks cast list-typed channel arguments to `ByteArray`, so they threw `ClassCastException` before doing any work. `advertiseResponseData` was unusable on Android as soon as it carried manufacturer or service data.

`AdvertiseData.toJson()` sends `manufacturerData` as a plain `List<int>` (via `Uint8ListConverter`) and `serviceData` is declared `List<int>` already, so both arrive as an `ArrayList<Integer>`, never a `ByteArray`. The primary block handled `manufacturerData` correctly; nothing else did.

### Fixed

- `responsemanufacturerData` / `periodicmanufacturerData` cast to `ByteArray` -> `ClassCastException`.
- `serviceData` cast to `ByteArray` in **all three** blocks, the primary one included -> `ClassCastException` whenever `serviceData` was set.
- Both guard conditions cast a String UUID (`responseserviceDataUuid`, `periodicServiceDataUuid`) to `ByteArray` -> `ClassCastException` before the block was even entered.
- The periodic block read `periodicServiceDataUuid`, `periodicServiceUuid` and `periodicManufacturerId` with capitals that Dart never sends.
- The guards ignored `serviceUuids`, so a scan response holding only the plural list built no response data at all.
- A short-form (16/32 bit) `serviceDataUuid` or `serviceSolicitationUuid` threw from `UUID.fromString`; both now go through `parseServiceUuid`, matching what #285 did for service uuids.

Byte payloads now go through one `readBytes` helper that accepts a `ByteArray` or a list of ints, and manufacturer/service data are read by prefix-driven helpers, in the same style as the `addServiceUuids` helper from #285. A missing `manufacturerId` or `serviceDataUuid` now raises a named `IllegalArgumentException` instead of an NPE.

Also commits the `analysis_options.yaml` excludes that `flutter build` writes ("Upgrading analysis_options.yaml to exclude build and platform directories"), so a fresh checkout is not dirty.

### Verification

`dart analyze` clean, 40 tests pass, example APK builds. Added a Dart test pinning the `response` prefixed wire format, including that the response data does not overwrite the primary payload.

### Not in this PR

- Android reads `transmissionPowerIncluded`, but Dart sends `includePowerLevel`, so the TX power flag is never applied on any of the three blocks.
- `start()` accepts `advertisePeriodicData` and `periodicAdvertiseSettings` but never puts any `periodic*` key on the channel, so the whole periodic block is still unreachable.
- `parameters["manufacturerDataBytes"]` is sent but never read on Android.
- `flutter_ble_peripheral.dart` has three redundant `parameters.addAll(advertiseData.toJson())` calls and a now-redundant manual `serviceUuids` assignment.