### PR TITLE
fix: apply tx power flags and send periodic advertise data on android

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
@@ -384,7 +384,7 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
         addServiceUuids(advertiseData, arguments)
         //TODO: addTransportDiscoveryData
         (arguments["includeDeviceName"] as Boolean?)?.let { advertiseData.setIncludeDeviceName(it) }
-        (arguments["transmissionPowerIncluded"] as Boolean?)?.let {
+        (arguments["includePowerLevel"] as Boolean?)?.let {
             advertiseData.setIncludeTxPowerLevel(it)
         }
 
@@ -401,7 +401,7 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
             addServiceUuids(advertiseResponseData, arguments, "response")
             //TODO: addTransportDiscoveryData
             (arguments["responseincludeDeviceName"] as Boolean?)?.let { advertiseResponseData.setIncludeDeviceName(it) }
-            (arguments["responsetransmissionPowerIncluded"] as Boolean?)?.let {
+            (arguments["responseincludePowerLevel"] as Boolean?)?.let {
                 advertiseResponseData.setIncludeTxPowerLevel(it)
             }
         }
@@ -413,7 +413,7 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
             val advertiseSettingsSet: AdvertisingSetParameters.Builder = AdvertisingSetParameters.Builder()
             (arguments["setanonymous"] as Boolean?)?.let { advertiseSettingsSet.setAnonymous(it) }
             (arguments["setconnectable"] as Boolean?)?.let { advertiseSettingsSet.setConnectable(it) }
-            (arguments["setsetIncludeTxPower"] as Boolean?)?.let { advertiseSettingsSet.setIncludeTxPower(it) }
+            (arguments["setincludeTxPowerLevel"] as Boolean?)?.let { advertiseSettingsSet.setIncludeTxPower(it) }
             (arguments["setinterval"] as Int?)?.let { advertiseSettingsSet.setInterval(it) }
             (arguments["setlegacyMode"] as Boolean?)?.let { advertiseSettingsSet.setLegacyMode(it) }
             (arguments["setprimaryPhy"] as Int?)?.let { advertiseSettingsSet.setPrimaryPhy(it) }
@@ -443,11 +443,11 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
                             it
                     )
                 }
-                (arguments["periodictransmissionPowerIncluded"] as Boolean?)?.let {
+                (arguments["periodicincludePowerLevel"] as Boolean?)?.let {
                     periodicAdvertiseData.setIncludeTxPowerLevel(it)
                 }
 
-                (arguments["periodicsettingstransmissionPowerIncluded"] as Boolean?)?.let {
+                (arguments["periodicsettingsincludeTxPowerLevel"] as Boolean?)?.let {
                     periodicAdvertiseDataSettings.setIncludeTxPower(it)
                 }
 

--- a/lib/flutter_ble_peripheral.dart
+++ b/lib/flutter_ble_peripheral.dart
@@ -6,5 +6,6 @@ export 'src/models/constants.dart';
 export 'src/models/enums/advertise_mode.dart';
 export 'src/models/enums/advertise_tx_power.dart';
 export 'src/models/enums/bluetooth_peripheral_state.dart';
+export 'src/models/periodic_advertise_settings.dart';
 export 'src/models/peripheral_state.dart';
 export 'src/models/permission_state.dart';

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -61,34 +61,34 @@ class FlutterBlePeripheral {
     AdvertiseData? advertisePeriodicData,
     PeriodicAdvertiseSettings? periodicAdvertiseSettings,
   }) async {
+    // The native side reads one flat map, where everything but the primary
+    // advertise data is namespaced by a prefix on the model's own json keys.
     final parameters = advertiseData.toJson();
-    parameters["manufacturerDataBytes"] = advertiseData.manufacturerData;
-    final settings = advertiseSettings ?? AdvertiseSettings();
-    final jsonSettings = settings.toJson();
-    for (final key in jsonSettings.keys) {
-      parameters[key] = jsonSettings[key];
+    // Windows reads the manufacturer data as a byte buffer rather than a list.
+    parameters['manufacturerDataBytes'] = advertiseData.manufacturerData;
+
+    void addPrefixed(String prefix, Map<String, dynamic> json) {
+      for (final key in json.keys) {
+        parameters['$prefix$key'] = json[key];
+      }
     }
 
-    if (advertiseData.serviceUuids != null) {
-      parameters['serviceUuids'] = advertiseData.serviceUuids;
-    }
-
-    parameters.addAll(advertiseData.toJson());
+    addPrefixed('', (advertiseSettings ?? AdvertiseSettings()).toJson());
 
     if (advertiseSetParameters != null) {
-      final json = advertiseSetParameters.toJson();
-      for (final key in json.keys) {
-        parameters['set$key'] = json[key];
-      }
-      parameters.addAll(advertiseData.toJson());
+      addPrefixed('set', advertiseSetParameters.toJson());
     }
 
     if (advertiseResponseData != null) {
-      final json = advertiseResponseData.toJson();
-      for (final key in json.keys) {
-        parameters['response$key'] = json[key];
-      }
-      parameters.addAll(advertiseData.toJson());
+      addPrefixed('response', advertiseResponseData.toJson());
+    }
+
+    if (advertisePeriodicData != null) {
+      addPrefixed('periodic', advertisePeriodicData.toJson());
+    }
+
+    if (periodicAdvertiseSettings != null) {
+      addPrefixed('periodicsettings', periodicAdvertiseSettings.toJson());
     }
 
     final response = await _methodChannel.invokeMethod<int>(

--- a/test/flutter_ble_peripheral_test.dart
+++ b/test/flutter_ble_peripheral_test.dart
@@ -154,6 +154,57 @@ void main() {
       expect(arguments['setprimaryPhy'], 1);
     });
 
+    test('prefixes the periodic data with periodic', () async {
+      await blePeripheral.start(
+        advertiseData: AdvertiseData(),
+        advertisePeriodicData: AdvertiseData(
+          serviceUuid: 'FEAA',
+          manufacturerId: 1234,
+          manufacturerData: Uint8List.fromList([1, 2, 3]),
+          includeDeviceName: true,
+        ),
+        periodicAdvertiseSettings: PeriodicAdvertiseSettings(
+          interval: 200,
+          includeTxPowerLevel: true,
+        ),
+      );
+
+      final arguments = argumentsOf(calls.single);
+      expect(arguments['periodicserviceUuid'], 'FEAA');
+      expect(arguments['periodicmanufacturerId'], 1234);
+      expect(arguments['periodicmanufacturerData'], const [1, 2, 3]);
+      expect(arguments['periodicincludeDeviceName'], true);
+      expect(arguments['periodicsettingsinterval'], 200);
+      expect(arguments['periodicsettingsincludeTxPowerLevel'], true);
+    });
+
+    test('omits the periodic keys when no periodic data is given', () async {
+      await blePeripheral.start(advertiseData: AdvertiseData());
+
+      final arguments = argumentsOf(calls.single);
+      expect(
+        arguments.keys.where((k) => (k! as String).startsWith('periodic')),
+        isEmpty,
+      );
+    });
+
+    // The native side switches the TX power flag on these keys, so they must
+    // keep the names the models serialise to.
+    test('sends the tx power flags under the model key names', () async {
+      await blePeripheral.start(
+        advertiseData: AdvertiseData(includePowerLevel: true),
+        advertiseResponseData: AdvertiseData(includePowerLevel: true),
+        advertiseSetParameters: AdvertiseSetParameters(
+          includeTxPowerLevel: true,
+        ),
+      );
+
+      final arguments = argumentsOf(calls.single);
+      expect(arguments['includePowerLevel'], true);
+      expect(arguments['responseincludePowerLevel'], true);
+      expect(arguments['setincludeTxPowerLevel'], true);
+    });
+
     test('maps a null response to unknown', () async {
       expect(
         await blePeripheral.start(advertiseData: AdvertiseData()),

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1,8 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:flutter_ble_peripheral/flutter_ble_peripheral.dart';
-// Not exported from the barrel file, even though start() takes one.
-import 'package:flutter_ble_peripheral/src/models/periodic_advertise_settings.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
## Description

The two follow-ups noted in #287. **Stacked on #287** — base is `fix/android-advertise-data-casts`, so review that one first; GitHub will retarget this to `develop` once it merges.

### TX power was never applied, on any path

Android read the flag under names the Dart models never serialise to, so every TX power request was silently dropped. All five reads were wrong:

| Android read | Dart sends |
|---|---|
| `transmissionPowerIncluded` | `includePowerLevel` |
| `responsetransmissionPowerIncluded` | `responseincludePowerLevel` |
| `periodictransmissionPowerIncluded` | `periodicincludePowerLevel` |
| `setsetIncludeTxPower` | `setincludeTxPowerLevel` |
| `periodicsettingstransmissionPowerIncluded` | `periodicsettingsincludeTxPowerLevel` |

Renamed the Android side to the model key names, so `AdvertiseData.includePowerLevel`, `AdvertiseSetParameters.includeTxPowerLevel` and `PeriodicAdvertiseSettings.includeTxPowerLevel` now reach `setIncludeTxPowerLevel` / `setIncludeTxPower`. No Dart API change.

### Periodic advertising never left Dart

`start()` accepted `advertisePeriodicData` and `periodicAdvertiseSettings` and dropped both on the floor: no `periodic*` key was ever put on the channel, so the entire periodic branch on Android was unreachable. They are now prefixed with `periodic` and `periodicsettings`, matching what the plugin reads.

`PeriodicAdvertiseSettings` was also missing from the barrel file, so callers could not construct the argument `start()` asks for. It is exported now, and the `src/` import that `models_test.dart` used to work around it is gone.

While wiring this up, the four hand-rolled prefix loops in `start()` collapsed into one `addPrefixed` helper. That also drops three no-op `parameters.addAll(advertiseData.toJson())` calls and a manual `serviceUuids` assignment made redundant by #285 — it is the duplication those loops carried that hid the response-data bug in #269.

### Verification

`dart analyze` clean, 43 tests pass, example APK builds. Added tests pinning the `periodic` and `periodicsettings` prefixes, that no `periodic*` key is sent when no periodic data is given, and that the TX power flags keep the model key names.

### Still open

`AdvertiseSetParameters.anonymous` is declared `int?` but Android reads `setanonymous` as a `Boolean`, so setting it throws `ClassCastException`. Left alone because the fix is a breaking change to the model's type.