### PR TITLE
fix: type AdvertiseSetParameters.anonymous as a bool

### DIFF
--- a/lib/src/models/advertise_set_parameters.dart
+++ b/lib/src/models/advertise_set_parameters.dart
@@ -6,7 +6,12 @@ part 'advertise_set_parameters.g.dart';
 /// Model of the data to be advertised.
 @JsonSerializable()
 class AdvertiseSetParameters {
-  final int? anonymous;
+  /// Android only
+  ///
+  /// Set whether the advertisement should be anonymous, omitting the device
+  /// address from it. Only available when advertising in non-legacy mode.
+  /// Default: false
+  final bool? anonymous;
 
   /// Android only
   ///

--- a/lib/src/models/advertise_set_parameters.g.dart
+++ b/lib/src/models/advertise_set_parameters.g.dart
@@ -17,7 +17,7 @@ AdvertiseSetParameters _$AdvertiseSetParametersFromJson(
       primaryPhy: (json['primaryPhy'] as num?)?.toInt(),
       scannable: json['scannable'] as bool?,
       secondaryPhy: (json['secondaryPhy'] as num?)?.toInt(),
-      anonymous: (json['anonymous'] as num?)?.toInt(),
+      anonymous: json['anonymous'] as bool?,
       includeTxPowerLevel: json['includeTxPowerLevel'] as bool? ?? false,
       duration: (json['duration'] as num?)?.toInt(),
       maxExtendedAdvertisingEvents:

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -128,6 +128,20 @@ void main() {
       expect(decoded.duration, 100);
       expect(decoded.maxExtendedAdvertisingEvents, 5);
     });
+
+    // Android reads setanonymous as a Boolean, so this has to go over the
+    // channel as a bool rather than an int.
+    test('encodes anonymous as a bool', () {
+      expect(
+          AdvertiseSetParameters(anonymous: true).toJson()['anonymous'], true);
+      expect(AdvertiseSetParameters().toJson()['anonymous'], isNull);
+      expect(
+        AdvertiseSetParameters.fromJson(
+          AdvertiseSetParameters(anonymous: true).toJson(),
+        ).anonymous,
+        true,
+      );
+    });
   });
 
   group('PeriodicAdvertiseSettings', () {


### PR DESCRIPTION
## Description

`AdvertiseSetParameters.anonymous` was declared `int?`, but Android reads it as a `Boolean`:

```kotlin
(arguments["setanonymous"] as Boolean?)?.let { advertiseSettingsSet.setAnonymous(it) }
```

An int arrives as an `Integer`, so the cast threw `ClassCastException` and `start()` failed. The flag could never be used at all.

`AdvertisingSetParameters.Builder.setAnonymous` takes a `boolean`, so the model was simply the wrong type. Retyped to `bool?`, regenerated `advertise_set_parameters.g.dart`, and documented what the flag does in the style of the neighbouring fields.

**No Android change is needed** — the existing `as Boolean?` cast becomes correct once Dart sends a bool. This is why the PR is independent of #287 and #288 and can merge in any order.

### On the breaking marker

Titled `fix!` because this is a source-breaking change: code written as `anonymous: 1` no longer compiles. It is worth weighing that against the fact that such code *crashes today*, so no working usage changes behaviour — nothing can be relying on the old type.

release-please will read the `!` and cut a major. If you would rather not spend 3.0.0 on this, retitle to a plain `fix:` before squash-merging, or say the word and I will convert it to a deprecated `int?` field alongside a properly typed replacement instead.

### Verification

`dart analyze` clean, 40 tests pass, example APK builds. Added a model test pinning `anonymous` to a bool on the wire, since that is the entire point of the fix.