### PR TITLE
fix: validate service uuids and advertise once powered on, on apple

### DIFF
--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
@@ -31,6 +31,12 @@ extension FlutterBlePeripheralManager: CBPeripheralManagerDelegate {
             state = .unknown
         }
         stateChangedHandler.publishPeripheralState(state: state)
+
+        // After publishing idle, so the advertising state that this produces is
+        // not overwritten by the state above.
+        if peripheral.state == .poweredOn {
+            startPendingAdvertisement()
+        }
     }
     
     func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: (any Error)?) {

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
@@ -45,26 +45,85 @@ class FlutterBlePeripheralManager : NSObject {
 //
 //    var txSubscriptions = Set<UUID>()
     
-    func start(advertiseData: FlutterBlePeripheralData) {
-        var dataToBeAdvertised: [String: Any]! = [:]
-        if (advertiseData.uuids != nil) {
-            dataToBeAdvertised[CBAdvertisementDataServiceUUIDsKey] = advertiseData.uuids!.map { CBUUID(string: $0) }
-        } else if (advertiseData.uuid != nil) {
-            dataToBeAdvertised[CBAdvertisementDataServiceUUIDsKey] = [CBUUID(string: advertiseData.uuid!)]
+    /// Set when `start` is called before the manager is powered on. Core Bluetooth
+    /// drops an advertisement issued in any other state, so it is kept here and
+    /// issued from `peripheralManagerDidUpdateState` once the radio comes up.
+    private var pendingAdvertisement: [String: Any]?
+
+    /// Parses a service uuid coming from Dart.
+    ///
+    /// `CBUUID(string:)` raises an Objective-C exception rather than returning nil
+    /// on a string it cannot parse, which cannot be caught from Swift and takes the
+    /// process down, so the string is validated first. The 16 bit ("A1B2") and
+    /// 32 bit ("A1B2C3D4") short forms are passed through as-is; a 128 bit uuid is
+    /// dashed before handing it over, since CBUUID only accepts that form.
+    static func parseServiceUuid(_ value: String) -> CBUUID? {
+        let hex = value.replacingOccurrences(of: "-", with: "")
+        guard hex.allSatisfy(\.isHexDigit) else { return nil }
+        switch hex.count {
+        case 4, 8:
+            return CBUUID(string: hex)
+        case 32:
+            let dashed = [
+                hex.prefix(8),
+                hex.dropFirst(8).prefix(4),
+                hex.dropFirst(12).prefix(4),
+                hex.dropFirst(16).prefix(4),
+                hex.dropFirst(20),
+            ].joined(separator: "-")
+            return CBUUID(string: dashed)
+        default:
+            return nil
         }
-        
+    }
+
+    func start(advertiseData: FlutterBlePeripheralData) throws {
+        var dataToBeAdvertised: [String: Any] = [:]
+
+        // When the plural uuids are set the singular uuid is not used, matching
+        // AdvertiseData.serviceUuids and the Android implementation.
+        let uuids = advertiseData.uuids ?? advertiseData.uuid.map { [$0] }
+        if let uuids = uuids, !uuids.isEmpty {
+            dataToBeAdvertised[CBAdvertisementDataServiceUUIDsKey] = try uuids.map {
+                guard let uuid = Self.parseServiceUuid($0) else {
+                    throw FlutterBlePeripheralError.invalidServiceUuid($0)
+                }
+                return uuid
+            }
+        }
+
         if (advertiseData.localName != nil) {
             dataToBeAdvertised[CBAdvertisementDataLocalNameKey] = advertiseData.localName
         }
         
         print("[flutter_ble_peripheral] start advertising data: \(String(describing: dataToBeAdvertised))")
-        
+
+        guard peripheralManager.state == .poweredOn else {
+            // Advertise as soon as the radio is up instead of dropping the call.
+            pendingAdvertisement = dataToBeAdvertised
+            return
+        }
+
+        pendingAdvertisement = nil
         peripheralManager.startAdvertising(dataToBeAdvertised)
         
 //         TODO: Add service to advertise
 //        if peripheralManager.state == .poweredOn {
 //            addService()
 //        }
+    }
+
+    func stop() {
+        // Drop anything queued, so a pending advertisement cannot start after stop.
+        pendingAdvertisement = nil
+        peripheralManager.stopAdvertising()
+    }
+
+    /// Issues the advertisement `start` queued while the radio was still coming up.
+    func startPendingAdvertisement() {
+        guard let pending = pendingAdvertisement else { return }
+        pendingAdvertisement = nil
+        peripheralManager.startAdvertising(pending)
     }
     
 // TODO: Add service to advertise

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
@@ -124,12 +124,18 @@ public class FlutterBlePeripheralPlugin: NSObject, FlutterPlugin {
             localName: map?["localName"] as? String,
             uuids: map?["serviceUuids"] as? [String] ,
         )
-        flutterBlePeripheralManager.start(advertiseData: advertiseData)
-        result(nil)
+        do {
+            try flutterBlePeripheralManager.start(advertiseData: advertiseData)
+            result(nil)
+        } catch let error as FlutterBlePeripheralError {
+            result(FlutterError(code: error.code, message: error.message, details: "startAdvertising"))
+        } catch {
+            result(FlutterError(code: "startAdvertising", message: error.localizedDescription, details: nil))
+        }
     }
     
     private func stopPeripheral(_ result: @escaping FlutterResult) {
-        flutterBlePeripheralManager.peripheralManager.stopAdvertising()
+        flutterBlePeripheralManager.stop()
         stateChangedHandler.publishPeripheralState(state: FlutterBlePeripheralState.idle)
         result(nil)
     }

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Models/FlutterBlePeripheralError.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Models/FlutterBlePeripheralError.swift
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026. Julian Steenbakker.
+ * All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+import Foundation
+
+/// A bad argument from Dart, reported back over the method channel as a
+/// PlatformException rather than crashing the process.
+enum FlutterBlePeripheralError: Error {
+    case invalidServiceUuid(String)
+
+    var code: String {
+        switch self {
+        case .invalidServiceUuid:
+            return "invalidServiceUuid"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .invalidServiceUuid(let value):
+            return "Invalid service uuid: \(value). Expected a 16 bit (\"A1B2\"), 32 bit (\"A1B2C3D4\") or 128 bit uuid."
+        }
+    }
+}


### PR DESCRIPTION
## Description

The two Apple-side issues found while auditing iOS/macOS against the Android fixes in #287, #288 and #289. Independent of all three — this touches only `darwin/`.

### A malformed service uuid crashed the app

`FlutterBlePeripheralManager.start` passed Dart strings straight into `CBUUID(string:)`, which is not a failable initialiser: it raises `NSInternalInconsistencyException`, which Swift cannot catch, so the process terminates. Verified with a compiled binary:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'String xyz does not represent a valid UUID'
libc++abi: terminating due to uncaught exception of type NSException
```

Android is strictly better here: `parseServiceUuid` throws `IllegalArgumentException`, which the method channel turns into a `PlatformException` back in Dart. Apple now behaves the same way, returning a `FlutterError` with an `invalidServiceUuid` code instead of taking the app down.

The same check turned up a parity gap: `CBUUID(string:)` **also** crashes on an undashed 128 bit uuid, which Android has accepted since #285. Those are now dashed before being handed over, so both platforms take the 16 bit, 32 bit, dashed and undashed 128 bit forms.

Since the singular/plural precedence was being touched anyway, it is now written the same way as Android's `addServiceUuids` — plural wins, singular is the fallback.

### Advertising was dropped when Bluetooth was not up yet

`start` called `startAdvertising` unconditionally. Core Bluetooth silently discards that unless the manager is `poweredOn`, so a `start()` issued during app startup, before the radio finished initialising, did nothing at all and reported no error. The advertisement is now queued and issued from `peripheralManagerDidUpdateState` once the state reaches `poweredOn`.

`stop()` clears the queue, so an advertisement queued before a stop cannot fire afterwards. The queued start runs *after* the state publish in the delegate, so the `advertising` state it produces is not overwritten by the `idle` published for `poweredOn`.

### Verification

The parser was run against real CoreBluetooth over 12 cases (short forms, dashed and undashed 128 bit, wrong lengths, non-hex, empty) — all pass, and the undashed form resolves to the same `CBUUID` as its dashed equivalent. Both `flutter build macos` and `flutter build ios` compile; `dart analyze` is clean and 39 tests pass.

### Note

`flutter build macos` wants to migrate the example to Swift Package Manager and bump its deployment target to 12.0, rewriting `Podfile`, `Podfile.lock`, `project.pbxproj` and the xcscheme. That is unrelated to this fix, so it is left out — but it is waiting for whoever next builds the macOS example.