### PR TITLE
fix: return the advertising state from start on every platform

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingCallback.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingCallback.kt
@@ -4,6 +4,7 @@ import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseSettings
 import dev.steenbakker.flutter_ble_peripheral.handlers.StateChangedHandler
 import dev.steenbakker.flutter_ble_peripheral.models.PeripheralState
+import dev.steenbakker.flutter_ble_peripheral.models.State
 import io.flutter.Log
 import io.flutter.plugin.common.MethodChannel
 
@@ -11,7 +12,7 @@ class PeripheralAdvertisingCallback(private val result: MethodChannel.Result, pr
     override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
         super.onStartSuccess(settingsInEffect)
         Log.i("FlutterBlePeripheral", "onStartSuccess() mode: ${settingsInEffect.mode}, txPOWER ${settingsInEffect.txPowerLevel}")
-        result.success(null)
+        result.success(State.Ready.ordinal)
         stateChangedHandler.publishPeripheralState(PeripheralState.advertising)
     }
 

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingSetCallback.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingSetCallback.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import dev.steenbakker.flutter_ble_peripheral.handlers.StateChangedHandler
 import dev.steenbakker.flutter_ble_peripheral.models.PeripheralState
+import dev.steenbakker.flutter_ble_peripheral.models.State
 import io.flutter.Log
 import io.flutter.plugin.common.MethodChannel
 
@@ -64,7 +65,7 @@ class PeripheralAdvertisingSetCallback(private val result: MethodChannel.Result,
         if (status != ADVERTISE_SUCCESS) {
             result.error(status.toString(), statusText, "startAdvertisingSet")
         } else {
-            result.success(0)
+            result.success(State.Ready.ordinal)
         }
 
     }

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/models/State.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/models/State.kt
@@ -6,25 +6,39 @@ package dev.steenbakker.flutter_ble_peripheral.models
  * BSD-style license that can be found in the LICENSE file.
  */
 
-enum class State(val value: Int) {
+/// The ordinal of each entry is the value sent to Dart, where it indexes
+/// BluetoothPeripheralState. Keep the order in sync with that enum.
+enum class State {
     /// The user granted access to the requested feature.
-    Granted(1),  /// The user denied access to the requested feature, permission needs to be asked first.
-    Denied(2),  /// Permission to the requested feature is permanently denied,
+    Granted,
 
+    /// The user denied access to the requested feature, permission needs to be asked first.
+    Denied,
+
+    /// Permission to the requested feature is permanently denied,
     /// the permission dialog will not be shown when requesting this permission.
     /// The user may still change the permission status in the settings.
-    PermanentlyDenied(3),  /// The status is unknown
-
+    PermanentlyDenied,
 
     /// The user cannot change this app's status, possibly due to active restrictions such as parental controls being in place.
     ///
     /// Only supported on iOS.
-    Restricted(4),  /// User has authorized this application for limited access.
+    Restricted,
 
+    /// User has authorized this application for limited access.
+    ///
     /// Only supported on iOS (iOS14+).
-    Limited(5),  /// Bluetooth is turned off
-    TurnedOff(6),
-    Unsupported(7),
-    Unknown(8),
-    Ready(9),
+    Limited,
+
+    /// Bluetooth is turned off.
+    TurnedOff,
+
+    /// Bluetooth is not supported on this device.
+    Unsupported,
+
+    /// The status is unknown.
+    Unknown,
+
+    /// Bluetooth is ready to be used.
+    Ready,
 }

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
@@ -80,8 +80,26 @@ public class FlutterBlePeripheralPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    // Returns permission state ordinal matching BluetoothPeripheralState enum
-    // 0=granted, 1=denied, 2=permanentlyDenied, 3=restricted, 7=unknown
+    /// What `start` reports back: `ready` once the advertisement is on air, or why
+    /// it is not. When the radio is still coming up the advertisement is queued and
+    /// issued on `poweredOn`, so `turnedOff` here is not a failure.
+    private func advertiseStartState() -> BluetoothPeripheralState {
+        switch flutterBlePeripheralManager.peripheralManager.state {
+        case .poweredOn:
+            return .ready
+        case .poweredOff:
+            return .turnedOff
+        case .unsupported:
+            return .unsupported
+        case .unauthorized:
+            return .permanentlyDenied
+        case .unknown, .resetting:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
+    }
+
     // Note: This checks PERMISSION status only, not Bluetooth power state (use isBluetoothOn for that)
     private func getPermissionState() -> Int {
         // First try the authorization API (iOS 13.1+/macOS 10.15+)
@@ -89,31 +107,32 @@ public class FlutterBlePeripheralPlugin: NSObject, FlutterPlugin {
         if #available(iOS 13.1, macOS 10.15, *) {
             switch CBPeripheralManager.authorization {
             case .allowedAlways:
-                return 0 // granted
+                return BluetoothPeripheralState.granted.rawValue
             case .denied:
-                return 2 // permanentlyDenied
+                return BluetoothPeripheralState.permanentlyDenied.rawValue
             case .restricted:
-                return 3 // restricted
+                return BluetoothPeripheralState.restricted.rawValue
             case .notDetermined:
-                return 1 // denied (needs to request)
+                // Denied, in the sense that it still has to be requested.
+                return BluetoothPeripheralState.denied.rawValue
             @unknown default:
                 break // fall through to state-based check
             }
         }
 
         // Fallback for older OS: infer permission from peripheral manager state
-        let state = flutterBlePeripheralManager.peripheralManager.state
-        switch state {
+        switch flutterBlePeripheralManager.peripheralManager.state {
         case .unauthorized:
-            return 2 // permanentlyDenied
+            return BluetoothPeripheralState.permanentlyDenied.rawValue
         case .poweredOn, .poweredOff:
-            return 0 // granted (if we get these states, we have permission)
+            // Reaching either state means permission was granted.
+            return BluetoothPeripheralState.granted.rawValue
         case .unsupported:
-            return 6 // unsupported
+            return BluetoothPeripheralState.unsupported.rawValue
         case .unknown, .resetting:
-            return 7 // unknown
+            return BluetoothPeripheralState.unknown.rawValue
         @unknown default:
-            return 7 // unknown
+            return BluetoothPeripheralState.unknown.rawValue
         }
     }
     
@@ -126,7 +145,7 @@ public class FlutterBlePeripheralPlugin: NSObject, FlutterPlugin {
         )
         do {
             try flutterBlePeripheralManager.start(advertiseData: advertiseData)
-            result(nil)
+            result(advertiseStartState().rawValue)
         } catch let error as FlutterBlePeripheralError {
             result(FlutterError(code: error.code, message: error.message, details: "startAdvertising"))
         } catch {
@@ -137,7 +156,7 @@ public class FlutterBlePeripheralPlugin: NSObject, FlutterPlugin {
     private func stopPeripheral(_ result: @escaping FlutterResult) {
         flutterBlePeripheralManager.stop()
         stateChangedHandler.publishPeripheralState(state: FlutterBlePeripheralState.idle)
-        result(nil)
+        result(BluetoothPeripheralState.ready.rawValue)
     }
     
     private func isSupported(_ result: @escaping FlutterResult) {

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Models/BluetoothPeripheralState.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Models/BluetoothPeripheralState.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026. Julian Steenbakker.
+ * All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+import Foundation
+
+/// Mirrors the Dart `BluetoothPeripheralState`.
+///
+/// The raw value is that enum's index, which is what `start`, `stop` and the
+/// permission methods return over the method channel. Keep the order in sync.
+enum BluetoothPeripheralState: Int {
+    case granted = 0
+    case denied = 1
+    case permanentlyDenied = 2
+    case restricted = 3
+    case limited = 4
+    case turnedOff = 5
+    case unsupported = 6
+    case unknown = 7
+    case ready = 8
+}

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -53,6 +53,12 @@ class FlutterBlePeripheral {
   //     'dev.steenbakker.flutter_ble_peripheral/ble_data_received');
 
   /// Start advertising. Takes [AdvertiseData] as an input.
+  ///
+  /// Returns [BluetoothPeripheralState.ready] once the advertisement is on air.
+  /// On Apple platforms a state such as [BluetoothPeripheralState.turnedOff] is
+  /// returned when the radio is not up yet; the advertisement is queued and
+  /// starts as soon as it is. A platform that refuses the advertisement outright
+  /// throws a [PlatformException] instead.
   Future<BluetoothPeripheralState> start({
     required AdvertiseData advertiseData,
     AdvertiseSettings? advertiseSettings,
@@ -100,7 +106,10 @@ class FlutterBlePeripheral {
         : BluetoothPeripheralState.values[response];
   }
 
-  /// Stop advertising
+  /// Stop advertising.
+  ///
+  /// Returns [BluetoothPeripheralState.ready], since the adapter is free to
+  /// advertise again.
   Future<BluetoothPeripheralState> stop() async {
     final response = await _methodChannel.invokeMethod<int>('stop');
     return response == null

--- a/test/flutter_ble_peripheral_test.dart
+++ b/test/flutter_ble_peripheral_test.dart
@@ -154,6 +154,18 @@ void main() {
       expect(arguments['setprimaryPhy'], 1);
     });
 
+    // Every platform reports ready on a successful start; the index has to line
+    // up with BluetoothPeripheralState or the state comes back as something else.
+    test('maps the native ready code to ready', () async {
+      response = BluetoothPeripheralState.ready.index;
+
+      expect(
+        await blePeripheral.start(advertiseData: AdvertiseData()),
+        BluetoothPeripheralState.ready,
+      );
+      expect(BluetoothPeripheralState.ready.index, 8);
+    });
+
     test('maps a null response to unknown', () async {
       expect(
         await blePeripheral.start(advertiseData: AdvertiseData()),
@@ -167,6 +179,11 @@ void main() {
       response = 5;
       expect(await blePeripheral.stop(), BluetoothPeripheralState.turnedOff);
       expect(calls.single.method, 'stop');
+    });
+
+    test('maps the native ready code to ready', () async {
+      response = BluetoothPeripheralState.ready.index;
+      expect(await blePeripheral.stop(), BluetoothPeripheralState.ready);
     });
 
     test('maps a null response to unknown', () async {


### PR DESCRIPTION
## Description

The last item from the audit: `start()`'s return value was meaningless. **Stacked on #290** — both touch `startPeripheral` on Apple; GitHub will retarget this to `develop` once #290 merges.

Windows was already correct, so it settles what the contract should be:

| | `start` returned | Dart saw |
|---|---|---|
| Windows | `8` | `ready` |
| Android, `stop` | `Ready.ordinal` (8) | `ready` |
| Android, legacy advertise | `null` | `unknown` |
| Android, advertising set | `0` | **`granted`** |
| Apple, `start` and `stop` | `nil` | `unknown` |

The advertising set path is the default, since `AdvertiseSettings.advertiseSet` defaults to `true`, so the common Android case reported a *permission* value for a successful advertisement.

Both Android callbacks now return `State.Ready.ordinal`. Apple returns `ready`, or the reason the radio cannot advertise yet — `turnedOff`, `unsupported`, `permanentlyDenied`, `unknown`. Combined with #290 that reads correctly: the advertisement is queued and starts on `poweredOn`, so `turnedOff` is information rather than a failure. Apple's `stop` returns `ready`, matching the other two platforms.

Deliberately *not* holding the `FlutterResult` on Apple until `peripheralManagerDidStartAdvertising`: with #290 queuing an advertisement while the radio is down, the result would never complete and `await start()` would hang indefinitely. Reporting the reachable state immediately is worse information but a working API.

### Two traps found on the way

Both are why this PR touches more than four lines:

`State.kt` declared `Granted(1) … Ready(9)`, but every call site uses `.ordinal`, which is 0-based — so `Ready.ordinal` is 8, and the `value` it carries is off by one from the number actually sent. Writing `Ready.value` would have sent 9 and thrown a `RangeError` in Dart on `values[9]`. The field was dead, so it is gone; the ordering contract is now a comment instead. The mangled trailing doc comments in that file are straightened out while there.

The Apple side hand-rolled the same ordinals as bare literals (`return 0 // granted`). Adding a second copy next to them was asking for drift, so there is now a `BluetoothPeripheralState` enum mirroring the Dart one, and `getPermissionState` uses it too. No behaviour change there.

### Verification

`dart analyze` clean, 41 tests pass (added ones pinning `ready` for both `start` and `stop`, and asserting its index really is 8). Builds: `flutter build apk`, `flutter build ios`, `flutter build macos`.