### PR TITLE
fix: apply tx power flags and send periodic advertise data on android

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
@@ -384,7 +384,7 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
         addServiceUuids(advertiseData, arguments)
         //TODO: addTransportDiscoveryData
         (arguments["includeDeviceName"] as Boolean?)?.let { advertiseData.setIncludeDeviceName(it) }
-        (arguments["transmissionPowerIncluded"] as Boolean?)?.let {
+        (arguments["includePowerLevel"] as Boolean?)?.let {
             advertiseData.setIncludeTxPowerLevel(it)
         }
 
@@ -401,7 +401,7 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
             addServiceUuids(advertiseResponseData, arguments, "response")
             //TODO: addTransportDiscoveryData
             (arguments["responseincludeDeviceName"] as Boolean?)?.let { advertiseResponseData.setIncludeDeviceName(it) }
-            (arguments["responsetransmissionPowerIncluded"] as Boolean?)?.let {
+            (arguments["responseincludePowerLevel"] as Boolean?)?.let {
                 advertiseResponseData.setIncludeTxPowerLevel(it)
             }
         }
@@ -413,7 +413,7 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
             val advertiseSettingsSet: AdvertisingSetParameters.Builder = AdvertisingSetParameters.Builder()
             (arguments["setanonymous"] as Boolean?)?.let { advertiseSettingsSet.setAnonymous(it) }
             (arguments["setconnectable"] as Boolean?)?.let { advertiseSettingsSet.setConnectable(it) }
-            (arguments["setsetIncludeTxPower"] as Boolean?)?.let { advertiseSettingsSet.setIncludeTxPower(it) }
+            (arguments["setincludeTxPowerLevel"] as Boolean?)?.let { advertiseSettingsSet.setIncludeTxPower(it) }
             (arguments["setinterval"] as Int?)?.let { advertiseSettingsSet.setInterval(it) }
             (arguments["setlegacyMode"] as Boolean?)?.let { advertiseSettingsSet.setLegacyMode(it) }
             (arguments["setprimaryPhy"] as Int?)?.let { advertiseSettingsSet.setPrimaryPhy(it) }
@@ -443,11 +443,11 @@ class FlutterBlePeripheralPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
                             it
                     )
                 }
-                (arguments["periodictransmissionPowerIncluded"] as Boolean?)?.let {
+                (arguments["periodicincludePowerLevel"] as Boolean?)?.let {
                     periodicAdvertiseData.setIncludeTxPowerLevel(it)
                 }
 
-                (arguments["periodicsettingstransmissionPowerIncluded"] as Boolean?)?.let {
+                (arguments["periodicsettingsincludeTxPowerLevel"] as Boolean?)?.let {
                     periodicAdvertiseDataSettings.setIncludeTxPower(it)
                 }
 

--- a/lib/flutter_ble_peripheral.dart
+++ b/lib/flutter_ble_peripheral.dart
@@ -6,5 +6,6 @@ export 'src/models/constants.dart';
 export 'src/models/enums/advertise_mode.dart';
 export 'src/models/enums/advertise_tx_power.dart';
 export 'src/models/enums/bluetooth_peripheral_state.dart';
+export 'src/models/periodic_advertise_settings.dart';
 export 'src/models/peripheral_state.dart';
 export 'src/models/permission_state.dart';

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -67,34 +67,34 @@ class FlutterBlePeripheral {
     AdvertiseData? advertisePeriodicData,
     PeriodicAdvertiseSettings? periodicAdvertiseSettings,
   }) async {
+    // The native side reads one flat map, where everything but the primary
+    // advertise data is namespaced by a prefix on the model's own json keys.
     final parameters = advertiseData.toJson();
-    parameters["manufacturerDataBytes"] = advertiseData.manufacturerData;
-    final settings = advertiseSettings ?? AdvertiseSettings();
-    final jsonSettings = settings.toJson();
-    for (final key in jsonSettings.keys) {
-      parameters[key] = jsonSettings[key];
+    // Windows reads the manufacturer data as a byte buffer rather than a list.
+    parameters['manufacturerDataBytes'] = advertiseData.manufacturerData;
+
+    void addPrefixed(String prefix, Map<String, dynamic> json) {
+      for (final key in json.keys) {
+        parameters['$prefix$key'] = json[key];
+      }
     }
 
-    if (advertiseData.serviceUuids != null) {
-      parameters['serviceUuids'] = advertiseData.serviceUuids;
-    }
-
-    parameters.addAll(advertiseData.toJson());
+    addPrefixed('', (advertiseSettings ?? AdvertiseSettings()).toJson());
 
     if (advertiseSetParameters != null) {
-      final json = advertiseSetParameters.toJson();
-      for (final key in json.keys) {
-        parameters['set$key'] = json[key];
-      }
-      parameters.addAll(advertiseData.toJson());
+      addPrefixed('set', advertiseSetParameters.toJson());
     }
 
     if (advertiseResponseData != null) {
-      final json = advertiseResponseData.toJson();
-      for (final key in json.keys) {
-        parameters['response$key'] = json[key];
-      }
-      parameters.addAll(advertiseData.toJson());
+      addPrefixed('response', advertiseResponseData.toJson());
+    }
+
+    if (advertisePeriodicData != null) {
+      addPrefixed('periodic', advertisePeriodicData.toJson());
+    }
+
+    if (periodicAdvertiseSettings != null) {
+      addPrefixed('periodicsettings', periodicAdvertiseSettings.toJson());
     }
 
     final response = await _methodChannel.invokeMethod<int>(

--- a/test/flutter_ble_peripheral_test.dart
+++ b/test/flutter_ble_peripheral_test.dart
@@ -20,9 +20,9 @@ void main() {
     response = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, (methodCall) async {
-      calls.add(methodCall);
-      return response;
-    });
+          calls.add(methodCall);
+          return response;
+        });
   });
 
   tearDown(() {
@@ -166,6 +166,57 @@ void main() {
       expect(BluetoothPeripheralState.ready.index, 8);
     });
 
+    test('prefixes the periodic data with periodic', () async {
+      await blePeripheral.start(
+        advertiseData: AdvertiseData(),
+        advertisePeriodicData: AdvertiseData(
+          serviceUuid: 'FEAA',
+          manufacturerId: 1234,
+          manufacturerData: Uint8List.fromList([1, 2, 3]),
+          includeDeviceName: true,
+        ),
+        periodicAdvertiseSettings: PeriodicAdvertiseSettings(
+          interval: 200,
+          includeTxPowerLevel: true,
+        ),
+      );
+
+      final arguments = argumentsOf(calls.single);
+      expect(arguments['periodicserviceUuid'], 'FEAA');
+      expect(arguments['periodicmanufacturerId'], 1234);
+      expect(arguments['periodicmanufacturerData'], const [1, 2, 3]);
+      expect(arguments['periodicincludeDeviceName'], true);
+      expect(arguments['periodicsettingsinterval'], 200);
+      expect(arguments['periodicsettingsincludeTxPowerLevel'], true);
+    });
+
+    test('omits the periodic keys when no periodic data is given', () async {
+      await blePeripheral.start(advertiseData: AdvertiseData());
+
+      final arguments = argumentsOf(calls.single);
+      expect(
+        arguments.keys.where((k) => (k! as String).startsWith('periodic')),
+        isEmpty,
+      );
+    });
+
+    // The native side switches the TX power flag on these keys, so they must
+    // keep the names the models serialise to.
+    test('sends the tx power flags under the model key names', () async {
+      await blePeripheral.start(
+        advertiseData: AdvertiseData(includePowerLevel: true),
+        advertiseResponseData: AdvertiseData(includePowerLevel: true),
+        advertiseSetParameters: AdvertiseSetParameters(
+          includeTxPowerLevel: true,
+        ),
+      );
+
+      final arguments = argumentsOf(calls.single);
+      expect(arguments['includePowerLevel'], true);
+      expect(arguments['responseincludePowerLevel'], true);
+      expect(arguments['setincludeTxPowerLevel'], true);
+    });
+
     test('maps a null response to unknown', () async {
       expect(
         await blePeripheral.start(advertiseData: AdvertiseData()),
@@ -199,10 +250,12 @@ void main() {
       expect(await blePeripheral.isSupported, true);
       expect(await blePeripheral.isConnected, true);
       expect(await blePeripheral.isBluetoothOn, true);
-      expect(
-        calls.map((c) => c.method),
-        ['isAdvertising', 'isSupported', 'isConnected', 'isBluetoothOn'],
-      );
+      expect(calls.map((c) => c.method), [
+        'isAdvertising',
+        'isSupported',
+        'isConnected',
+        'isBluetoothOn',
+      ]);
     });
 
     test('fall back to false when the native side returns null', () async {
@@ -238,10 +291,10 @@ void main() {
         BluetoothPeripheralState.denied,
       );
 
-      expect(
-        calls.map((c) => c.method),
-        ['requestPermission', 'hasPermission'],
-      );
+      expect(calls.map((c) => c.method), [
+        'requestPermission',
+        'hasPermission',
+      ]);
     }, skip: Platform.isWindows);
 
     test('map a null response to unknown', () async {
@@ -300,10 +353,10 @@ void main() {
       await blePeripheral.openBluetoothSettings();
       await blePeripheral.openAppSettings();
 
-      expect(
-        calls.map((c) => c.method),
-        ['openBluetoothSettings', 'openAppSettings'],
-      );
+      expect(calls.map((c) => c.method), [
+        'openBluetoothSettings',
+        'openAppSettings',
+      ]);
     });
 
     test('the Windows-only ones are no-ops elsewhere', () async {
@@ -321,14 +374,11 @@ void main() {
       await blePeripheral.openLocationSettings();
       expect(await blePeripheral.isNearbyShareEnabled(), true);
 
-      expect(
-        calls.map((c) => c.method),
-        [
-          'openNearbyShareSettings',
-          'openLocationSettings',
-          'isNearbyShareEnabled',
-        ],
-      );
+      expect(calls.map((c) => c.method), [
+        'openNearbyShareSettings',
+        'openLocationSettings',
+        'isNearbyShareEnabled',
+      ]);
     }, skip: !Platform.isWindows);
   });
 }

--- a/test/flutter_ble_peripheral_test.dart
+++ b/test/flutter_ble_peripheral_test.dart
@@ -20,9 +20,9 @@ void main() {
     response = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, (methodCall) async {
-          calls.add(methodCall);
-          return response;
-        });
+      calls.add(methodCall);
+      return response;
+    });
   });
 
   tearDown(() {

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1,8 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:flutter_ble_peripheral/flutter_ble_peripheral.dart';
-// Not exported from the barrel file, even though start() takes one.
-import 'package:flutter_ble_peripheral/src/models/periodic_advertise_settings.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -133,7 +131,9 @@ void main() {
     // channel as a bool rather than an int.
     test('encodes anonymous as a bool', () {
       expect(
-          AdvertiseSetParameters(anonymous: true).toJson()['anonymous'], true);
+        AdvertiseSetParameters(anonymous: true).toJson()['anonymous'],
+        true,
+      );
       expect(AdvertiseSetParameters().toJson()['anonymous'], isNull);
       expect(
         AdvertiseSetParameters.fromJson(
@@ -180,11 +180,17 @@ void main() {
     // declared order has to stay in step with the native enums.
     test('index matches the native state code', () {
       expect(
-          BluetoothPeripheralState.values[0], BluetoothPeripheralState.granted);
-      expect(BluetoothPeripheralState.values[5],
-          BluetoothPeripheralState.turnedOff);
+        BluetoothPeripheralState.values[0],
+        BluetoothPeripheralState.granted,
+      );
       expect(
-          BluetoothPeripheralState.values[8], BluetoothPeripheralState.ready);
+        BluetoothPeripheralState.values[5],
+        BluetoothPeripheralState.turnedOff,
+      );
+      expect(
+        BluetoothPeripheralState.values[8],
+        BluetoothPeripheralState.ready,
+      );
       expect(BluetoothPeripheralState.values, hasLength(9));
     });
   });


### PR DESCRIPTION
## Description

Re-lands #288. It was stacked on #287's branch, and got merged into that branch
instead of develop right after #287 was squashed, so its changes never landed.
Cherry-pick of 19c0eab onto develop.

Fixes tx power being dropped everywhere (android read the flag under names the
models don't serialise to) and periodic advertise data never being sent to the
platform at all.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [x] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
