### PR TITLE
chore: migrate lints to very_good_analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           #    declares. This mirrors flutter/packages' .ci/scripts/analyze_legacy.sh, and is
           #    why this row analyzes lib/ only.
           yq -i 'del(.dev_dependencies)' pubspec.yaml
-          # 2. analysis_options.yaml pulls the `lint` package in by `package:`
+          # 2. analysis_options.yaml pulls very_good_analysis in by `package:`
           #    URI, which stops resolving once the dev dependency is gone.
           printf 'analyzer:\n  errors:\n    lines_longer_than_80_chars: ignore\n' > analysis_options.yaml
           # 3. The example app has its own, unrelated dependency floors.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/flutter_ble_peripheral?include_prereleases)](https://pub.dev/packages/flutter_ble_peripheral)
 [![CI](https://github.com/juliansteenbakker/flutter_ble_peripheral/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/juliansteenbakker/flutter_ble_peripheral/actions/workflows/ci.yml)
-[![style: lint](https://img.shields.io/badge/style-lint-4BC0F5.svg)](https://pub.dev/packages/lint)
+[![style: very good analysis](https://img.shields.io/badge/style-very_good_analysis-B22C89.svg)](https://pub.dev/packages/very_good_analysis)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/juliansteenbakker)](https://github.com/sponsors/juliansteenbakker)
 
 Advertise over Bluetooth Low Energy from Flutter. This plugin puts the device in

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,5 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:lint/analysis_options_package.yaml
+    # json_serializable output; not ours to lint or document.
+    - "**/*.g.dart"

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,4 +9,12 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: package:lint/analysis_options.yaml
+
+linter:
+  rules:
+    # The example is an app, not a published API, so its widgets and their
+    # members do not need doc comments.
+    public_member_api_docs: false
+    # Firing a future from a button callback without awaiting it is the normal
+    # shape of a Flutter event handler.
+    discarded_futures: false

--- a/example/lib/ble_status_screen.dart
+++ b/example/lib/ble_status_screen.dart
@@ -9,17 +9,21 @@ class BleStatusScreen extends StatelessWidget {
   String determineText(PeripheralState status) {
     switch (status) {
       case PeripheralState.unsupported:
-        return "This device does not support Bluetooth";
+        return 'This device does not support Bluetooth';
       case PeripheralState.unauthorized:
-        return "Authorize the BlePeripheral example app to use Bluetooth and location";
+        return 'Authorize the BlePeripheral example app to use Bluetooth '
+            'and location';
       case PeripheralState.poweredOff:
-        return "Bluetooth is powered off on your device turn it on";
+        return 'Bluetooth is powered off on your device turn it on';
       // case PeripheralState.unauthorized:
       //   return "Enable location services";
       case PeripheralState.idle:
-        return "Bluetooth is up and running";
-      default:
-        return "Waiting to fetch Bluetooth status $status";
+        return 'Bluetooth is up and running';
+      case PeripheralState.unknown:
+      case PeripheralState.advertising:
+      case PeripheralState.connected:
+      case PeripheralState.shouldShowRequestPermissionRationale:
+        return 'Waiting to fetch Bluetooth status $status';
     }
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,6 @@
  */
 
 import 'dart:io';
-// ignore: unnecessary_import
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -57,7 +56,7 @@ class FlutterBlePeripheralExampleState
           input.split(RegExp(r'[\s,]+')).where((s) => s.isNotEmpty);
       final bytes = hexValues.map((hex) => int.parse(hex, radix: 16)).toList();
       return Uint8List.fromList(bytes);
-    } catch (e) {
+    } on FormatException {
       return null;
     }
   }
@@ -134,13 +133,14 @@ class FlutterBlePeripheralExampleState
     showDialog<void>(
       context: navigatorContext,
       barrierDismissible: false,
-      builder: (BuildContext dialogContext) {
+      builder: (dialogContext) {
         return AlertDialog(
           icon:
               const Icon(Icons.bluetooth_disabled, color: Colors.red, size: 48),
           title: const Text('Bluetooth Not Supported'),
           content: const Text(
-            'This device does not support Bluetooth Low Energy (BLE) peripheral mode.\n\n'
+            'This device does not support Bluetooth Low Energy (BLE) '
+            'peripheral mode.\n\n'
             'BLE advertising requires compatible hardware.',
           ),
           actions: <Widget>[
@@ -161,7 +161,7 @@ class FlutterBlePeripheralExampleState
     return showDialog<bool>(
       context: navigatorContext,
       barrierDismissible: false,
-      builder: (BuildContext dialogContext) {
+      builder: (dialogContext) {
         return _BluetoothOffDialog(
           onEnabled: () => _showSnackBar('Bluetooth enabled!'),
         );
@@ -170,14 +170,15 @@ class FlutterBlePeripheralExampleState
   }
 
   Future<bool?> _showPermissionDialog(
-      BluetoothPeripheralState initialState) async {
+    BluetoothPeripheralState initialState,
+  ) async {
     final navigatorContext = _navigatorKey.currentContext;
     if (navigatorContext == null) return false;
 
     return showDialog<bool>(
       context: navigatorContext,
       barrierDismissible: false,
-      builder: (BuildContext dialogContext) {
+      builder: (dialogContext) {
         return _PermissionDialog(
           initialState: initialState,
           onGranted: () => _showSnackBar('Permission granted!'),
@@ -193,10 +194,13 @@ class FlutterBlePeripheralExampleState
     showDialog<void>(
       context: navigatorContext,
       barrierDismissible: false,
-      builder: (BuildContext dialogContext) {
+      builder: (dialogContext) {
         return AlertDialog(
-          icon: const Icon(Icons.warning_amber_rounded,
-              color: Colors.orange, size: 48),
+          icon: const Icon(
+            Icons.warning_amber_rounded,
+            color: Colors.orange,
+            size: 48,
+          ),
           title: const Text('Nearby Sharing Detected'),
           content: const Text(
             'Windows Nearby Sharing is currently enabled. This may interfere '
@@ -464,9 +468,8 @@ class FlutterBlePeripheralExampleState
 }
 
 class _StatusCard extends StatelessWidget {
-  final bool isSupported;
-
   const _StatusCard({required this.isSupported});
+  final bool isSupported;
 
   @override
   Widget build(BuildContext context) {
@@ -540,7 +543,9 @@ class _StatusCard extends StatelessWidget {
   }
 
   (IconData, Color, String) _getStateInfo(
-      PeripheralState state, ColorScheme colorScheme) {
+    PeripheralState state,
+    ColorScheme colorScheme,
+  ) {
     return switch (state) {
       PeripheralState.advertising => (
           Icons.broadcast_on_personal,
@@ -570,15 +575,14 @@ class _StatusCard extends StatelessWidget {
 }
 
 class _SectionCard extends StatelessWidget {
-  final String title;
-  final IconData icon;
-  final List<Widget> children;
-
   const _SectionCard({
     required this.title,
     required this.icon,
     required this.children,
   });
+  final String title;
+  final IconData icon;
+  final List<Widget> children;
 
   @override
   Widget build(BuildContext context) {
@@ -610,17 +614,16 @@ class _SectionCard extends StatelessWidget {
 }
 
 class _ActionTile extends StatelessWidget {
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final VoidCallback onTap;
-
   const _ActionTile({
     required this.icon,
     required this.title,
     required this.subtitle,
     required this.onTap,
   });
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -636,17 +639,16 @@ class _ActionTile extends StatelessWidget {
 }
 
 class _AdvertiseConfigCard extends StatefulWidget {
-  final TextEditingController serviceUuidController;
-  final TextEditingController localNameController;
-  final TextEditingController manufacturerIdController;
-  final TextEditingController manufacturerDataController;
-
   const _AdvertiseConfigCard({
     required this.serviceUuidController,
     required this.localNameController,
     required this.manufacturerIdController,
     required this.manufacturerDataController,
   });
+  final TextEditingController serviceUuidController;
+  final TextEditingController localNameController;
+  final TextEditingController manufacturerIdController;
+  final TextEditingController manufacturerDataController;
 
   @override
   State<_AdvertiseConfigCard> createState() => _AdvertiseConfigCardState();
@@ -730,8 +732,11 @@ class _AdvertiseConfigCardState extends State<_AdvertiseConfigCard> {
                   const SizedBox(height: 16),
                   Row(
                     children: [
-                      const Icon(Icons.info_outline,
-                          size: 16, color: Colors.grey),
+                      const Icon(
+                        Icons.info_outline,
+                        size: 16,
+                        color: Colors.grey,
+                      ),
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
@@ -759,13 +764,12 @@ class _AdvertiseConfigCardState extends State<_AdvertiseConfigCard> {
 }
 
 class _PermissionDialog extends StatefulWidget {
-  final VoidCallback onGranted;
-  final BluetoothPeripheralState initialState;
-
   const _PermissionDialog({
     required this.onGranted,
     required this.initialState,
   });
+  final VoidCallback onGranted;
+  final BluetoothPeripheralState initialState;
 
   @override
   State<_PermissionDialog> createState() => _PermissionDialogState();
@@ -850,11 +854,14 @@ class _PermissionDialogState extends State<_PermissionDialog>
         size: 48,
       ),
       title: Text(
-          _isPermanentlyDenied ? 'Permission Denied' : 'Permission Required'),
+        _isPermanentlyDenied ? 'Permission Denied' : 'Permission Required',
+      ),
       content: Text(
         _isPermanentlyDenied
-            ? 'Bluetooth permission was denied. You can only grant permission through the app settings.\n\n'
-                'Please open Settings and enable Bluetooth permissions for this app.'
+            ? 'Bluetooth permission was denied. You can only grant '
+                'permission through the app settings.\n\n'
+                'Please open Settings and enable Bluetooth permissions '
+                'for this app.'
             : 'BLE advertising requires Bluetooth permissions.\n\n'
                 'Please grant the required permissions to continue.',
       ),
@@ -961,10 +968,9 @@ class _PermissionDialogState extends State<_PermissionDialog>
 }
 
 class _StepItem extends StatelessWidget {
+  const _StepItem({required this.number, required this.text});
   final String number;
   final String text;
-
-  const _StepItem({required this.number, required this.text});
 
   @override
   Widget build(BuildContext context) {
@@ -1000,9 +1006,8 @@ class _StepItem extends StatelessWidget {
 }
 
 class _BluetoothOffDialog extends StatefulWidget {
-  final VoidCallback onEnabled;
-
   const _BluetoothOffDialog({required this.onEnabled});
+  final VoidCallback onEnabled;
 
   @override
   State<_BluetoothOffDialog> createState() => _BluetoothOffDialogState();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -98,14 +98,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  lint:
-    dependency: "direct dev"
-    description:
-      name: lint
-      sha256: "3cd03646de313481336500ba02eb34d07c590535525f154aae7fda7362aa07a9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.8.0"
   matcher:
     dependency: transitive
     description:
@@ -199,6 +191,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
+  very_good_analysis:
+    dependency: "direct dev"
+    description:
+      name: very_good_analysis
+      sha256: "481af67ab5877af20325251dc215a4ebac7666a1c8cf09198ffd457bc612b33d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.0"
   vm_service:
     dependency: transitive
     description:
@@ -208,5 +208,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.11.0-0 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^2.0.1
+  very_good_analysis: ^10.0.0
 
 flutter:
   uses-material-design: true

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -6,6 +6,8 @@
 
 import 'dart:async';
 import 'dart:io';
+// Needed on older SDKs, where Uint8List is not re-exported by
+// package:flutter/services.dart.
 // ignore: unnecessary_import
 import 'dart:typed_data';
 
@@ -17,11 +19,8 @@ import 'package:flutter_ble_peripheral/src/models/enums/bluetooth_peripheral_sta
 import 'package:flutter_ble_peripheral/src/models/periodic_advertise_settings.dart';
 import 'package:flutter_ble_peripheral/src/models/peripheral_state.dart';
 
+/// Advertises this device as a BLE peripheral.
 class FlutterBlePeripheral {
-  /// Singleton instance
-  static final FlutterBlePeripheral _instance =
-      FlutterBlePeripheral._internal();
-
   /// Singleton factory
   factory FlutterBlePeripheral() {
     return _instance;
@@ -29,6 +28,10 @@ class FlutterBlePeripheral {
 
   /// Singleton constructor
   FlutterBlePeripheral._internal();
+
+  /// Singleton instance
+  static final FlutterBlePeripheral _instance =
+      FlutterBlePeripheral._internal();
 
   /// Method Channel used to communicate state with
   static const MethodChannel _methodChannel = MethodChannel(
@@ -48,7 +51,7 @@ class FlutterBlePeripheral {
   Stream<int>? _mtuState;
   Stream<PeripheralState>? _peripheralState;
 
-  //TODO Event Channel used to received data
+  // TODO(juliansteenbakker): event channel used to receive data.
   // final EventChannel _dataReceivedEventChannel = const EventChannel(
   //     'dev.steenbakker.flutter_ble_peripheral/ble_data_received');
 
@@ -57,8 +60,8 @@ class FlutterBlePeripheral {
   /// Returns [BluetoothPeripheralState.ready] once the advertisement is on air.
   /// On Apple platforms a state such as [BluetoothPeripheralState.turnedOff] is
   /// returned when the radio is not up yet; the advertisement is queued and
-  /// starts as soon as it is. A platform that refuses the advertisement outright
-  /// throws a [PlatformException] instead.
+  /// starts as soon as it is. A platform that refuses the advertisement
+  /// outright throws a [PlatformException] instead.
   Future<BluetoothPeripheralState> start({
     required AdvertiseData advertiseData,
     AdvertiseSettings? advertiseSettings,
@@ -205,10 +208,13 @@ class FlutterBlePeripheral {
         : BluetoothPeripheralState.values[response];
   }
 
+  /// Opens the Bluetooth settings, or the app settings on iOS, where
+  /// Bluetooth cannot be reached directly.
   Future<void> openBluetoothSettings() async {
     await _methodChannel.invokeMethod('openBluetoothSettings');
   }
 
+  /// Opens this app's settings page.
   Future<void> openAppSettings() async {
     await _methodChannel.invokeMethod('openAppSettings');
   }
@@ -226,7 +232,8 @@ class FlutterBlePeripheral {
   /// Checks if Windows Nearby Sharing is enabled.
   ///
   /// Returns `true` if Nearby Sharing is set to "My devices only" or
-  /// "Everyone nearby". Returns `false` if it's off or on non-Windows platforms.
+  /// "Everyone nearby". Returns `false` if it is off, or on a non-Windows
+  /// platform.
   ///
   /// Nearby Sharing can interfere with BLE advertising on Windows.
   Future<bool> isNearbyShareEnabled() async {
@@ -257,7 +264,8 @@ class FlutterBlePeripheral {
 
   /// Returns Stream of state.
   ///
-  /// After listening to this Stream, you'll be notified about changes in peripheral state.
+  /// After listening to this Stream, you'll be notified about changes in
+  /// peripheral state.
   Stream<PeripheralState>? get onPeripheralStateChanged {
     _peripheralState ??= _stateChangedEventChannel.receiveBroadcastStream().map(
           (dynamic event) => PeripheralState.values[event as int],
@@ -269,6 +277,8 @@ class FlutterBlePeripheral {
   // ///
   // ///
   // Stream<Uint8List> getDataReceived() {
-  //   return _dataReceivedEventChannel.receiveBroadcastStream().cast<Uint8List>();
+  //   return _dataReceivedEventChannel
+  //       .receiveBroadcastStream()
+  //       .cast<Uint8List>();
   // }
 }

--- a/lib/src/models/advertise_data.dart
+++ b/lib/src/models/advertise_data.dart
@@ -14,11 +14,34 @@ part 'advertise_data.g.dart';
 /// Model of the data to be advertised.
 @JsonSerializable()
 class AdvertiseData {
+  /// Creates the data to advertise.
+  AdvertiseData({
+    // @Deprecated(
+    //   'Please use serviceUuids, where you can also define a single '
+    //   'service uuid.',
+    // )
+    this.serviceUuid,
+    this.serviceUuids,
+    this.manufacturerId,
+    this.manufacturerData,
+    this.serviceDataUuid,
+    this.serviceData,
+    this.includeDeviceName = false,
+    this.localName,
+    this.includePowerLevel = false,
+    this.serviceSolicitationUuid,
+  });
+
+  /// Creates advertise data from the map [toJson] produces.
+  factory AdvertiseData.fromJson(Map<String, dynamic> json) =>
+      _$AdvertiseDataFromJson(json);
+
   /// Android & iOS
   ///
   /// Specifies a single service UUIDs to be advertised
   // @Deprecated(
-  //   'Please use serviceUuids, where you can also define a single service uuid.',
+  //   'Please use serviceUuids, where you can also define a single '
+  //   'service uuid.',
   // )
   final String? serviceUuid;
 
@@ -76,24 +99,6 @@ class AdvertiseData {
   /// A service solicitation UUID to advertise data.
   final String? serviceSolicitationUuid;
 
-  AdvertiseData({
-    // @Deprecated(
-    //   'Please use serviceUuids, where you can also define a single service uuid.',
-    // )
-    this.serviceUuid,
-    this.serviceUuids,
-    this.manufacturerId,
-    this.manufacturerData,
-    this.serviceDataUuid,
-    this.serviceData,
-    this.includeDeviceName = false,
-    this.localName,
-    this.includePowerLevel = false,
-    this.serviceSolicitationUuid,
-  });
-
-  factory AdvertiseData.fromJson(Map<String, dynamic> json) =>
-      _$AdvertiseDataFromJson(json);
-
+  /// The map sent over the method channel to the platform.
   Map<String, dynamic> toJson() => _$AdvertiseDataToJson(this);
 }

--- a/lib/src/models/advertise_set_parameters.dart
+++ b/lib/src/models/advertise_set_parameters.dart
@@ -3,44 +3,13 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'advertise_set_parameters.g.dart';
 
-/// Model of the data to be advertised.
+/// Parameters for an advertising set, used on Android 8 and up.
+///
+/// These map onto Android's `AdvertisingSetParameters`, which is what the
+/// plugin advertises with when [AdvertiseSettings.advertiseSet] is set.
 @JsonSerializable()
 class AdvertiseSetParameters {
-  /// Android only
-  ///
-  /// Set whether the advertisement should be anonymous, omitting the device
-  /// address from it. Only available when advertising in non-legacy mode.
-  /// Default: false
-  final bool? anonymous;
-
-  /// Android only
-  ///
-  /// Set whether the advertisement type should be connectable or non-connectable.
-  /// Default: false
-  final bool connectable;
-
-  final bool? includeTxPowerLevel;
-
-  final int? interval;
-
-  final bool? legacyMode;
-
-  final int? primaryPhy;
-
-  final bool? scannable;
-
-  final int? secondaryPhy;
-
-  /// Android only
-  ///
-  /// Set advertise TX power level to control the transmission power level for the advertising.
-  /// Default: AdvertisePower.ADVERTISE_TX_POWER_HIGH
-  final int txPowerLevel;
-
-  final int? duration;
-
-  final int? maxExtendedAdvertisingEvents;
-
+  /// Creates the parameters for an advertising set.
   AdvertiseSetParameters({
     this.connectable = false,
     this.txPowerLevel = txPowerHigh,
@@ -55,8 +24,85 @@ class AdvertiseSetParameters {
     this.maxExtendedAdvertisingEvents,
   });
 
+  /// Creates parameters from the map [toJson] produces.
   factory AdvertiseSetParameters.fromJson(Map<String, dynamic> json) =>
       _$AdvertiseSetParametersFromJson(json);
 
+  /// Android only
+  ///
+  /// Set whether the advertisement should be anonymous, omitting the device
+  /// address from it. Only available when advertising in non-legacy mode.
+  /// Default: false
+  final bool? anonymous;
+
+  /// Android only
+  ///
+  /// Set whether the advertisement type should be connectable or
+  /// non-connectable.
+  /// Default: false
+  final bool connectable;
+
+  /// Android only
+  ///
+  /// Set whether the TX power level should be included in the advertisement.
+  /// Default: false
+  final bool? includeTxPowerLevel;
+
+  /// Android only
+  ///
+  /// How often to advertise, in units of 0.625 ms. See [intervalLow],
+  /// [intervalMedium] and [intervalHigh], or pass a value between
+  /// [intervalMin] and [intervalMax].
+  /// Default: [intervalHigh]
+  final int? interval;
+
+  /// Android only
+  ///
+  /// Set whether to advertise in the legacy format, so that devices without
+  /// Bluetooth 5 support can still see the advertisement. Turning this off
+  /// allows a larger payload, at the cost of reaching fewer devices.
+  /// Default: false
+  final bool? legacyMode;
+
+  /// Android only
+  ///
+  /// The PHY to advertise the primary advertisement on. Accepts the values of
+  /// Android's `BluetoothDevice.PHY_LE_*` constants.
+  final int? primaryPhy;
+
+  /// Android only
+  ///
+  /// Set whether the advertisement should be scannable, meaning a central may
+  /// ask for the scan response data.
+  final bool? scannable;
+
+  /// Android only
+  ///
+  /// The PHY to advertise the secondary advertisement on. Accepts the values of
+  /// Android's `BluetoothDevice.PHY_LE_*` constants, and is ignored in
+  /// [legacyMode].
+  final int? secondaryPhy;
+
+  /// Android only
+  ///
+  /// Set advertise TX power level to control the transmission power level for
+  /// the advertising. See [txPowerLow], [txPowerMedium] and [txPowerHigh], or
+  /// pass a value in dBm between [txPowerMin] and [txPowerMax].
+  /// Default: [txPowerHigh]
+  final int txPowerLevel;
+
+  /// Android only
+  ///
+  /// How long to advertise for, in units of 10 ms. Advertises until stopped
+  /// when left unset.
+  final int? duration;
+
+  /// Android only
+  ///
+  /// How many extended advertising events to send before stopping. Sends them
+  /// until stopped when left unset.
+  final int? maxExtendedAdvertisingEvents;
+
+  /// The map sent over the method channel to the platform.
   Map<String, dynamic> toJson() => _$AdvertiseSetParametersToJson(this);
 }

--- a/lib/src/models/advertise_settings.dart
+++ b/lib/src/models/advertise_settings.dart
@@ -7,6 +7,19 @@ part 'advertise_settings.g.dart';
 /// Model of the data to be advertised.
 @JsonSerializable()
 class AdvertiseSettings {
+  /// Creates the settings to advertise with.
+  AdvertiseSettings({
+    this.advertiseSet = true,
+    this.connectable = false,
+    this.timeout = 400,
+    this.advertiseMode = AdvertiseMode.advertiseModeLowLatency,
+    this.txPowerLevel = AdvertiseTxPower.advertiseTxPowerLow,
+  });
+
+  /// Creates settings from the map [toJson] produces.
+  factory AdvertiseSettings.fromJson(Map<String, dynamic> json) =>
+      _$AdvertiseSettingsFromJson(json);
+
   /// Android only
   ///
   /// Set the advertise mode to use when using android >= o
@@ -20,7 +33,8 @@ class AdvertiseSettings {
 
   /// Android only
   ///
-  /// Set whether the advertisement type should be connectable or non-connectable.
+  /// Set whether the advertisement type should be connectable or
+  /// non-connectable.
   /// Default: false
   final bool connectable;
 
@@ -33,20 +47,11 @@ class AdvertiseSettings {
 
   /// Android only
   ///
-  /// Set advertise TX power level to control the transmission power level for the advertising.
-  /// Default: AdvertisePower.ADVERTISE_TX_POWER_HIGH
+  /// Set advertise TX power level to control the transmission power level for
+  /// the advertising.
+  /// Default: [AdvertiseTxPower.advertiseTxPowerLow]
   final AdvertiseTxPower txPowerLevel;
 
-  AdvertiseSettings({
-    this.advertiseSet = true,
-    this.connectable = false,
-    this.timeout = 400,
-    this.advertiseMode = AdvertiseMode.advertiseModeLowLatency,
-    this.txPowerLevel = AdvertiseTxPower.advertiseTxPowerLow,
-  });
-
-  factory AdvertiseSettings.fromJson(Map<String, dynamic> json) =>
-      _$AdvertiseSettingsFromJson(json);
-
+  /// The map sent over the method channel to the platform.
   Map<String, dynamic> toJson() => _$AdvertiseSettingsToJson(this);
 }

--- a/lib/src/models/constants.dart
+++ b/lib/src/models/constants.dart
@@ -3,16 +3,46 @@
  * All rights reserved. Use of this source code is governed by a
  * BSD-style license that can be found in the LICENSE file.
  */
-// TODO: Docs
+
+/// Advertising intervals and TX power levels for `AdvertiseSetParameters`,
+/// mirroring the constants on Android's `AdvertisingSetParameters`.
+///
+/// Intervals are counted in units of 0.625 ms, so 160 is every 100 ms.
+/// A shorter interval is discovered faster but costs more power.
+library;
+
+/// Advertise every 100 ms. The most responsive of the presets, and the
+/// most power hungry.
 const int intervalLow = 160;
+
+/// Advertise every second. The least power hungry of the presets, and the
+/// slowest to be discovered.
 const int intervalHigh = 1600;
+
+/// The longest interval the platform accepts.
 const int intervalMax = 16777215;
+
+/// Advertise every 250 ms.
 const int intervalMedium = 400;
+
+/// The shortest interval the platform accepts, equal to [intervalLow].
 const int intervalMin = 160;
 
+/// Transmit at 1 dBm, the strongest of the presets. Gives the longest range.
 const int txPowerHigh = 1;
+
+/// Transmit at -15 dBm.
 const int txPowerLow = -15;
+
+/// The strongest power the platform accepts, equal to [txPowerHigh].
 const int txPowerMax = 1;
+
+/// Transmit at -7 dBm.
 const int txPowerMedium = -7;
+
+/// The weakest power the platform accepts. Effectively disables advertising
+/// beyond a few centimetres.
 const int txPowerMin = -127;
+
+/// Transmit at -21 dBm, for advertising only to devices held very close.
 const int txPowerUltraLow = -21;

--- a/lib/src/models/enums/advertise_mode.dart
+++ b/lib/src/models/enums/advertise_mode.dart
@@ -6,19 +6,23 @@
 
 import 'package:json_annotation/json_annotation.dart';
 
+/// The trade-off between advertising frequency and power consumption.
+///
+/// Android only; maps onto `AdvertiseSettings.ADVERTISE_MODE_*`.
 enum AdvertiseMode {
-  /// Perform Bluetooth LE advertising in low power mode. This is the default and preferred
-  /// advertising mode as it consumes the least power.
+  /// Perform Bluetooth LE advertising in low power mode. This is the default
+  /// and preferred advertising mode as it consumes the least power.
   @JsonValue(0)
   advertiseModeLowPower,
 
-  /// Perform Bluetooth LE advertising in balanced power mode. This is balanced between advertising
-  /// frequency and power consumption.
+  /// Perform Bluetooth LE advertising in balanced power mode. This is balanced
+  /// between advertising frequency and power consumption.
   @JsonValue(1)
   advertiseModeBalanced,
 
-  /// Perform Bluetooth LE advertising in low latency, high power mode. This has the highest power
-  /// consumption and should not be used for continuous background advertising.
+  /// Perform Bluetooth LE advertising in low latency, high power mode. This has
+  /// the highest power consumption and should not be used for continuous
+  /// background advertising.
   @JsonValue(2)
   advertiseModeLowLatency,
 }

--- a/lib/src/models/enums/advertise_tx_power.dart
+++ b/lib/src/models/enums/advertise_tx_power.dart
@@ -6,9 +6,13 @@
 
 import 'package:json_annotation/json_annotation.dart';
 
+/// The transmission power to advertise at, which sets how far the
+/// advertisement carries.
+///
+/// Android only; maps onto `AdvertiseSettings.ADVERTISE_TX_POWER_*`.
 enum AdvertiseTxPower {
-  /// Advertise using the lowest transmission (TX) power level. Low transmission power can be used
-  /// to restrict the visibility range of advertising packets.
+  /// Advertise using the lowest transmission (TX) power level. Low transmission
+  /// power can be used to restrict the visibility range of advertising packets.
   @JsonValue(0)
   advertiseTxPowerUltraLow,
 
@@ -20,8 +24,8 @@ enum AdvertiseTxPower {
   @JsonValue(2)
   advertiseTxPowerMedium,
 
-  /// Advertise using high TX power level. This corresponds to largest visibility range of the
-  /// advertising packet.
+  /// Advertise using high TX power level. This corresponds to the largest
+  /// visibility range of the advertising packet.
   @JsonValue(3)
   advertiseTxPowerHigh,
 }

--- a/lib/src/models/enums/bluetooth_peripheral_state.dart
+++ b/lib/src/models/enums/bluetooth_peripheral_state.dart
@@ -6,12 +6,18 @@
 
 import 'package:json_annotation/json_annotation.dart';
 
+/// The result of a call that reaches the platform, covering both permission
+/// state and whether the adapter can be used.
+///
+/// The index of each entry is the value the platform sends back, so the order
+/// must not change.
 enum BluetoothPeripheralState {
   /// The user granted access to the requested feature.
   @JsonValue(0)
   granted,
 
-  /// The user denied access to the requested feature, permission needs to be asked first.
+  /// The user denied access to the requested feature, permission needs to be
+  /// asked first.
   @JsonValue(1)
   denied,
 
@@ -22,10 +28,10 @@ enum BluetoothPeripheralState {
   permanentlyDenied,
 
   /// The OS denied access to the requested feature.
-  /// The user cannot change this app's status, possibly due to active restrictions such as parental controls being in place.
+  /// The user cannot change this app's status, possibly due to active
+  /// restrictions such as parental controls being in place.
   ///
   /// Only supported on iOS.
-  ///
   @JsonValue(3)
   restricted,
 
@@ -37,12 +43,16 @@ enum BluetoothPeripheralState {
   /// Bluetooth is turned off
   @JsonValue(5)
   turnedOff,
+
+  /// Bluetooth is not supported on this device.
   @JsonValue(6)
   unsupported,
 
   /// The status is unknown
   @JsonValue(7)
   unknown,
+
+  /// Bluetooth is ready to be used.
   @JsonValue(8)
   ready,
 }

--- a/lib/src/models/map_uint8list_converter.dart
+++ b/lib/src/models/map_uint8list_converter.dart
@@ -1,8 +1,11 @@
 import 'dart:typed_data';
 import 'package:json_annotation/json_annotation.dart';
 
+/// Encodes a map of byte payloads keyed by int, such as manufacturer data
+/// keyed by manufacturer id, as json with the keys turned into strings.
 class Uint8ListMapIntConverter
     implements JsonConverter<Map<int, Uint8List>?, Map<String, dynamic>?> {
+  /// Creates the converter.
   const Uint8ListMapIntConverter();
 
   @override
@@ -11,7 +14,7 @@ class Uint8ListMapIntConverter
       return null;
     }
 
-    final Map<int, Uint8List> map = {};
+    final map = <int, Uint8List>{};
     for (final key in json.keys) {
       map[int.parse(key)] = Uint8List.fromList((json[key] as List).cast<int>());
     }
@@ -24,7 +27,7 @@ class Uint8ListMapIntConverter
     if (object == null) {
       return null;
     }
-    final Map<String, dynamic> map = {};
+    final map = <String, dynamic>{};
     for (final key in object.keys) {
       map[key.toString()] = object[key]!.toList();
     }

--- a/lib/src/models/periodic_advertise_settings.dart
+++ b/lib/src/models/periodic_advertise_settings.dart
@@ -2,20 +2,28 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'periodic_advertise_settings.g.dart';
 
-/// Model of the data to be advertised.
+/// Settings for the periodic advertisement of an advertising set.
+///
+/// Only used on Android 8 and up, alongside `AdvertiseSetParameters`.
 @JsonSerializable()
 class PeriodicAdvertiseSettings {
-  final int? interval;
-
-  final bool? includeTxPowerLevel;
-
+  /// Creates the settings for a periodic advertisement.
   PeriodicAdvertiseSettings({
     this.interval = 100,
     this.includeTxPowerLevel = false,
   });
 
+  /// Creates settings from the map [toJson] produces.
   factory PeriodicAdvertiseSettings.fromJson(Map<String, dynamic> json) =>
       _$PeriodicAdvertiseSettingsFromJson(json);
 
+  /// How often to send the periodic advertisement, in units of 1.25 ms.
+  final int? interval;
+
+  /// Whether the TX power level should be included in the periodic
+  /// advertisement.
+  final bool? includeTxPowerLevel;
+
+  /// The map sent over the method channel to the platform.
   Map<String, dynamic> toJson() => _$PeriodicAdvertiseSettingsToJson(this);
 }

--- a/lib/src/models/peripheral_state.dart
+++ b/lib/src/models/peripheral_state.dart
@@ -4,6 +4,10 @@
  * BSD-style license that can be found in the LICENSE file.
  */
 
+/// The live advertising state, as published on the state change stream.
+///
+/// The index of each entry is the value the platform sends, so the order must
+/// not change.
 enum PeripheralState {
   /// Status is not (yet) determined.
   unknown,
@@ -29,5 +33,7 @@ enum PeripheralState {
   /// BLE is connected to a device.
   connected,
 
+  /// Android only: the permission was denied once, so a rationale should be
+  /// shown before asking again.
   shouldShowRequestPermissionRationale,
 }

--- a/lib/src/models/permission_state.dart
+++ b/lib/src/models/permission_state.dart
@@ -4,11 +4,13 @@
  * BSD-style license that can be found in the LICENSE file.
  */
 
+/// Whether this app may use Bluetooth.
 enum PermissionState {
   /// The user granted access to the requested feature.
   granted,
 
-  /// The user denied access to the requested feature, permission needs to be asked first.
+  /// The user denied access to the requested feature, permission needs to be
+  /// asked first.
   denied,
 
   /// Permission to the requested feature is permanently denied,
@@ -20,7 +22,8 @@ enum PermissionState {
   unknown,
 
   /// The OS denied access to the requested feature.
-  /// The user cannot change this app's status, possibly due to active restrictions such as parental controls being in place.
+  /// The user cannot change this app's status, possibly due to active
+  /// restrictions such as parental controls being in place.
   ///
   /// Only supported on iOS.
   restricted,

--- a/lib/src/models/uint8list_converter.dart
+++ b/lib/src/models/uint8list_converter.dart
@@ -1,7 +1,10 @@
 import 'dart:typed_data';
 import 'package:json_annotation/json_annotation.dart';
 
+/// Encodes a [Uint8List] as a plain list of ints, so that it survives the
+/// json round trip that `AdvertiseData` uses.
 class Uint8ListConverter implements JsonConverter<Uint8List?, List<dynamic>?> {
+  /// Creates the converter.
   const Uint8ListConverter();
 
   @override

--- a/lib/src/models/uint8list_map_string_converter.dart
+++ b/lib/src/models/uint8list_map_string_converter.dart
@@ -1,8 +1,11 @@
 import 'dart:typed_data';
 import 'package:json_annotation/json_annotation.dart';
 
+/// Encodes a map of byte payloads keyed by string, such as service data
+/// keyed by service uuid, as json.
 class Uint8ListMapStringConverter
     implements JsonConverter<Map<String, Uint8List>?, Map<String, dynamic>?> {
+  /// Creates the converter.
   const Uint8ListMapStringConverter();
 
   @override
@@ -11,8 +14,8 @@ class Uint8ListMapStringConverter
       return null;
     }
 
-    final Map<String, Uint8List> map = {};
-    for (final String key in json.keys) {
+    final map = <String, Uint8List>{};
+    for (final key in json.keys) {
       map[key] = Uint8List.fromList((json[key] as List).cast<int>());
     }
 
@@ -24,7 +27,7 @@ class Uint8ListMapStringConverter
     if (object == null) {
       return null;
     }
-    final Map<String, dynamic> map = {};
+    final map = <String, dynamic>{};
     for (final key in object.keys) {
       map[key] = object[key]!.toList();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   json_serializable: ^6.6.1
-  lint: ^2.0.1
+  very_good_analysis: ^10.0.0
 
 flutter:
   plugin:

--- a/test/flutter_ble_peripheral_test.dart
+++ b/test/flutter_ble_peripheral_test.dart
@@ -154,8 +154,9 @@ void main() {
       expect(arguments['setprimaryPhy'], 1);
     });
 
-    // Every platform reports ready on a successful start; the index has to line
-    // up with BluetoothPeripheralState or the state comes back as something else.
+    // Every platform reports ready on a successful start; the index has to
+    // line up with BluetoothPeripheralState or the state comes back as
+    // something else.
     test('maps the native ready code to ready', () async {
       response = BluetoothPeripheralState.ready.index;
 
@@ -278,53 +279,65 @@ void main() {
   });
 
   group('permissions', () {
-    test('map the response to a state', () async {
-      response = 2;
-      expect(
-        await blePeripheral.requestPermission(),
-        BluetoothPeripheralState.permanentlyDenied,
-      );
+    test(
+      'map the response to a state',
+      () async {
+        response = 2;
+        expect(
+          await blePeripheral.requestPermission(),
+          BluetoothPeripheralState.permanentlyDenied,
+        );
 
-      response = 1;
-      expect(
-        await blePeripheral.hasPermission(),
-        BluetoothPeripheralState.denied,
-      );
+        response = 1;
+        expect(
+          await blePeripheral.hasPermission(),
+          BluetoothPeripheralState.denied,
+        );
 
-      expect(calls.map((c) => c.method), [
-        'requestPermission',
-        'hasPermission',
-      ]);
-    }, skip: Platform.isWindows);
+        expect(calls.map((c) => c.method), [
+          'requestPermission',
+          'hasPermission',
+        ]);
+      },
+      skip: Platform.isWindows,
+    );
 
-    test('map a null response to unknown', () async {
-      expect(
-        await blePeripheral.requestPermission(),
-        BluetoothPeripheralState.unknown,
-      );
-      expect(
-        await blePeripheral.hasPermission(),
-        BluetoothPeripheralState.unknown,
-      );
-    }, skip: Platform.isWindows);
+    test(
+      'map a null response to unknown',
+      () async {
+        expect(
+          await blePeripheral.requestPermission(),
+          BluetoothPeripheralState.unknown,
+        );
+        expect(
+          await blePeripheral.hasPermission(),
+          BluetoothPeripheralState.unknown,
+        );
+      },
+      skip: Platform.isWindows,
+    );
 
     // Windows has no Bluetooth permission of its own; the plugin asks for the
     // location permission that BLE requires and reduces it to granted/denied.
-    test('go through the location permission on Windows', () async {
-      response = true;
-      expect(
-        await blePeripheral.requestPermission(),
-        BluetoothPeripheralState.granted,
-      );
-      expect(calls.single.method, 'requestLocationPermission');
+    test(
+      'go through the location permission on Windows',
+      () async {
+        response = true;
+        expect(
+          await blePeripheral.requestPermission(),
+          BluetoothPeripheralState.granted,
+        );
+        expect(calls.single.method, 'requestLocationPermission');
 
-      response = false;
-      expect(
-        await blePeripheral.hasPermission(),
-        BluetoothPeripheralState.denied,
-      );
-      expect(calls.last.method, 'hasLocationPermission');
-    }, skip: !Platform.isWindows);
+        response = false;
+        expect(
+          await blePeripheral.hasPermission(),
+          BluetoothPeripheralState.denied,
+        );
+        expect(calls.last.method, 'hasLocationPermission');
+      },
+      skip: !Platform.isWindows,
+    );
   });
 
   group('enableBluetooth', () {
@@ -359,26 +372,34 @@ void main() {
       ]);
     });
 
-    test('the Windows-only ones are no-ops elsewhere', () async {
-      await blePeripheral.openNearbyShareSettings();
-      await blePeripheral.openLocationSettings();
+    test(
+      'the Windows-only ones are no-ops elsewhere',
+      () async {
+        await blePeripheral.openNearbyShareSettings();
+        await blePeripheral.openLocationSettings();
 
-      expect(await blePeripheral.isNearbyShareEnabled(), false);
-      expect(calls, isEmpty);
-    }, skip: Platform.isWindows);
+        expect(await blePeripheral.isNearbyShareEnabled(), false);
+        expect(calls, isEmpty);
+      },
+      skip: Platform.isWindows,
+    );
 
-    test('the Windows-only ones reach the channel on Windows', () async {
-      response = true;
+    test(
+      'the Windows-only ones reach the channel on Windows',
+      () async {
+        response = true;
 
-      await blePeripheral.openNearbyShareSettings();
-      await blePeripheral.openLocationSettings();
-      expect(await blePeripheral.isNearbyShareEnabled(), true);
+        await blePeripheral.openNearbyShareSettings();
+        await blePeripheral.openLocationSettings();
+        expect(await blePeripheral.isNearbyShareEnabled(), true);
 
-      expect(calls.map((c) => c.method), [
-        'openNearbyShareSettings',
-        'openLocationSettings',
-        'isNearbyShareEnabled',
-      ]);
-    }, skip: !Platform.isWindows);
+        expect(calls.map((c) => c.method), [
+          'openNearbyShareSettings',
+          'openLocationSettings',
+          'isNearbyShareEnabled',
+        ]);
+      },
+      skip: !Platform.isWindows,
+    );
   });
 }


### PR DESCRIPTION
## Description

Swaps the `lint` package for `very_good_analysis`, in the plugin and the
example, and clears the 144 issues it reported. Most of those were missing doc
comments on the public models; the rest is line wrapping and what `dart fix`
applies.

Two opt-outs: generated `.g.dart` files are excluded, since json_serializable
output isn't ours to lint or document, and the example turns off
`public_member_api_docs` and `discarded_futures` because it's an app, not a
published API.

No behaviour change in `lib/` — everything there is docs, quote style and
constructor ordering. The example has two real ones: the hex parser now catches
`FormatException` instead of everything, and `determineText` lists the remaining
`PeripheralState` values instead of using `default`, so adding a state becomes a
compile error rather than silently falling through.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.
