### PR TITLE
fix: return the converted map from Uint8ListMapStringConverter.toJson

### DIFF
--- a/lib/src/models/uint8list_map_string_converter.dart
+++ b/lib/src/models/uint8list_map_string_converter.dart
@@ -27,10 +27,12 @@ class Uint8ListMapStringConverter
     if (object == null) {
       return null;
     }
-    final map = <String, dynamic>{};
-    for (final key in object.keys) {
-      map[key] = object[key]!.toList();
+
+    final map = <String, List<int>>{};
+    for (final entry in object.entries) {
+      map[entry.key] = entry.value.toList();
     }
-    return object;
+
+    return map;
   }
 }

--- a/test/converters_test.dart
+++ b/test/converters_test.dart
@@ -81,6 +81,9 @@ void main() {
       expect(converter.toJson(decoded), {
         uuid: const [16, 32],
       });
+      // Not a Uint8List: the method channel encodes one as a byte array rather
+      // than a list, and a plain int list is what the platform side reads.
+      expect(converter.toJson(decoded)![uuid], isNot(isA<Uint8List>()));
     });
 
     test('passes null through', () {


### PR DESCRIPTION
## Description

`Uint8ListMapStringConverter.toJson` built the converted map and then returned
`object`, its own input, discarding the work. So the values came back as
`Uint8List` instead of plain int lists, which the method channel encodes as a
byte array rather than a list — a different shape than the sibling
`Uint8ListMapIntConverter` produces.

Nothing uses the converter yet, so this is inert today.

The existing test passed either way, because `Uint8List` compares equal to
`List<int>`. Added an assertion that doesn't, and checked it fails on the old
code.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [x] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
