### PR TITLE
chore: refresh the flutter revision in .metadata

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -1,11 +1,11 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled.
+# This file should be version controlled and should not be manually edited.
 
 version:
-  revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
-  channel: stable
+  revision: "4cf24164269a5ebf0c16a028a00727d0e77bbb05"
+  channel: "stable"
 
 project_type: plugin
 
@@ -14,19 +14,19 @@ migration:
   platforms:
     - platform: root
       create_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
-      base_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
+      base_revision: 4cf24164269a5ebf0c16a028a00727d0e77bbb05
     - platform: android
       create_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
-      base_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
+      base_revision: 4cf24164269a5ebf0c16a028a00727d0e77bbb05
     - platform: ios
       create_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
-      base_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
+      base_revision: 4cf24164269a5ebf0c16a028a00727d0e77bbb05
     - platform: macos
       create_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
-      base_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
+      base_revision: 4cf24164269a5ebf0c16a028a00727d0e77bbb05
     - platform: windows
       create_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
-      base_revision: 2ad6cd72c040113b47ee9055e722606a490ef0da
+      base_revision: 4cf24164269a5ebf0c16a028a00727d0e77bbb05
 
   # User provided section
 


### PR DESCRIPTION
## Description

`.metadata` still pointed at `2ad6cd72c0`, a flutter 2.x revision, so
`flutter migrate` had a four year old base to diff against and could not say
anything useful.

Bumped `version.revision` and every `base_revision` to the current stable
revision (3.47.0, `4cf2416426`). `create_revision` is left alone, since that
records when each platform was actually added rather than what it has been
migrated to.

I checked the tree really is level with the current template before claiming it:
`.gitignore` and `example/.gitignore` are byte identical to a freshly generated
plugin, `Package.swift` uses the current FlutterFramework dependency, the android
build is Kotlin DSL on compileSdk 36 with Java 17, and the example is on SPM with
no Podfiles. The remaining differences are deliberate: lower platform floors and
minSdk, no buildscript block, and a shared `darwin/` directory instead of
separate `ios/` and `macos/` ones.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
