### PR TITLE
feat: honour the advertise timeout on windows

### DIFF
--- a/lib/src/models/advertise_settings.dart
+++ b/lib/src/models/advertise_settings.dart
@@ -38,10 +38,11 @@ class AdvertiseSettings {
   /// Default: false
   final bool connectable;
 
-  /// Android only
+  /// Android and Windows only
   ///
-  /// Limit advertising to a given amount of time.
-  /// May not exceed 180000 milliseconds.
+  /// Limit advertising to a given amount of time, and only when [advertiseSet]
+  /// is false, since an advertising set is limited by its own duration instead.
+  /// May not exceed 180000 milliseconds; 0 leaves the advertisement up.
   /// Default: 400 milliseconds
   final int timeout;
 

--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -21,11 +21,9 @@
 
 #include <algorithm>
 #include <array>
-#include <iomanip>
 #include <map>
 #include <memory>
 #include <optional>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -53,31 +51,12 @@ namespace flutter_ble_peripheral {
                 registrar->messenger(), "dev.steenbakker.flutter_ble_peripheral/ble_state_changed",
                 &flutter::StandardMethodCodec::GetInstance());
 
-        auto event_scan_result =
-            std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-                registrar->messenger(), "dev.steenbakker.flutter_ble_peripheral/scan_result",
-                &flutter::StandardMethodCodec::GetInstance());
-
         auto plugin = std::make_unique<FlutterBlePeripheralPlugin>();
 
         channel->SetMethodCallHandler(
             [plugin_pointer = plugin.get()](const auto& call, auto result) {
                 plugin_pointer->HandleMethodCall(call, std::move(result));
             });
-
-        auto scan_handler = std::make_unique<
-            flutter::StreamHandlerFunctions<>>(
-                [plugin_pointer = plugin.get()](
-                    const flutter::EncodableValue* arguments,
-                    std::unique_ptr<flutter::EventSink<>>&& events)
-                -> std::unique_ptr<flutter::StreamHandlerError<>> {
-                    return plugin_pointer->OnListen(arguments, std::move(events));
-                },
-                [plugin_pointer = plugin.get()](const flutter::EncodableValue* arguments)
-                    -> std::unique_ptr<flutter::StreamHandlerError<>> {
-                    return plugin_pointer->OnCancel(arguments);
-                });
-        event_scan_result->SetStreamHandler(std::move(scan_handler));
 
         auto state_handler = std::make_unique<
             flutter::StreamHandlerFunctions<>>(
@@ -729,79 +708,6 @@ namespace flutter_ble_peripheral {
         }
     }
 
-    union uint16_t_union {
-        uint16_t uint16;
-        byte bytes[sizeof(uint16_t)];
-    };
-
-    std::vector<uint8_t> to_bytevc(IBuffer buffer) {
-        try {
-            if (!buffer) {
-                return std::vector<uint8_t>();
-            }
-            auto reader = DataReader::FromBuffer(buffer);
-            auto result = std::vector<uint8_t>(reader.UnconsumedBufferLength());
-            reader.ReadBytes(result);
-            return result;
-        }
-        catch (...) {
-            return std::vector<uint8_t>();
-        }
-    }
-
-    std::vector<uint8_t> parseManufacturerData(BluetoothLEAdvertisement advertisement) {
-        try {
-            if (advertisement.ManufacturerData().Size() == 0)
-                return std::vector<uint8_t>();
-
-            auto manufacturerData = advertisement.ManufacturerData().GetAt(0);
-            // FIXME Compat with REG_DWORD_BIG_ENDIAN
-            uint8_t* prefix = uint16_t_union{ manufacturerData.CompanyId() }.bytes;
-            auto result = std::vector<uint8_t>{ prefix, prefix + sizeof(uint16_t_union) };
-
-            auto data = to_bytevc(manufacturerData.Data());
-            result.insert(result.end(), data.begin(), data.end());
-            return result;
-        }
-        catch (...) {
-            return std::vector<uint8_t>();
-        }
-    }
-
-    winrt::fire_and_forget FlutterBlePeripheralPlugin::BluetoothLEWatcher_Received(
-        BluetoothLEAdvertisementWatcher sender,
-        BluetoothLEAdvertisementReceivedEventArgs args) {
-        try {
-            // Extract all data on the callback thread first
-            auto manufacturer_data = parseManufacturerData(args.Advertisement());
-            auto bluetoothAddress = args.BluetoothAddress();
-            auto localName = args.Advertisement().LocalName();
-            auto name = winrt::to_string(localName);
-            if (localName.empty()) {
-                std::stringstream sstream;
-                sstream << std::hex << bluetoothAddress;
-                name = sstream.str();
-            }
-            auto rssi = args.RawSignalStrengthInDBm();
-            auto address = std::to_string(bluetoothAddress);
-
-            // Switch to UI thread before sending to Flutter
-            co_await ui_thread_;
-
-            if (scan_result_sink_) {
-                scan_result_sink_->Success(flutter::EncodableMap{
-                    {"deviceName", name},
-                    {"address", address},
-                    {"manufacturerSpecificData", manufacturer_data},
-                    {"rssi", rssi},
-                });
-            }
-        }
-        catch (...) {
-            // Silently ignore failed advertisement processing
-        }
-    }
-
     winrt::fire_and_forget FlutterBlePeripheralPlugin::OnRadioStateChanged(Radio sender, IInspectable args) {
         auto alive = alive_;
         try {
@@ -823,22 +729,6 @@ namespace flutter_ble_peripheral {
         catch (...) {
             // Ignore state change errors
         }
-    }
-
-
-
-    std::unique_ptr<flutter::StreamHandlerError<flutter::EncodableValue>> FlutterBlePeripheralPlugin::OnListenInternal(
-        const flutter::EncodableValue* arguments, std::unique_ptr<flutter::EventSink<flutter::EncodableValue>>&& events)
-    {
-        scan_result_sink_ = std::move(events);
-        return nullptr;
-    }
-
-    std::unique_ptr<flutter::StreamHandlerError<flutter::EncodableValue>> FlutterBlePeripheralPlugin::OnCancelInternal(
-        const flutter::EncodableValue* arguments)
-    {
-        scan_result_sink_ = nullptr;
-        return nullptr;
     }
 
 }  // namespace flutter_ble_peripheral

--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <optional>
@@ -142,6 +143,9 @@ namespace flutter_ble_peripheral {
             PublishState(state);
         }
     }
+
+    // What Android caps AdvertiseSettings.timeout at.
+    constexpr std::chrono::milliseconds kMaxAdvertiseTimeout{ 180000 };
 
     // The tail of the Bluetooth Base UUID, onto which the 16 and 32 bit short
     // forms of a service uuid are expanded.
@@ -282,6 +286,13 @@ namespace flutter_ble_peripheral {
         return std::nullopt;
     }
 
+    std::optional<bool> ReadBool(const EncodableMap& arguments, const char* key) {
+        auto it = arguments.find(EncodableValue(key));
+        if (it == arguments.end()) return std::nullopt;
+        if (const auto* value = std::get_if<bool>(&it->second)) return *value;
+        return std::nullopt;
+    }
+
     std::optional<std::int64_t> ReadInt(const EncodableMap& arguments, const char* key) {
         auto it = arguments.find(EncodableValue(key));
         if (it == arguments.end()) return std::nullopt;
@@ -305,6 +316,16 @@ namespace flutter_ble_peripheral {
         // Rebuild from scratch, so repeated calls do not stack up.
         advertisement.ManufacturerData().Clear();
         advertisement.DataSections().Clear();
+
+        // Android reads the timeout on its legacy path only, where the advertising
+        // set path uses a duration Windows has no equivalent for, and treats zero
+        // as no limit. Same here, so that the two agree on when advertising ends.
+        advertise_timeout_ = std::chrono::milliseconds::zero();
+        if (!ReadBool(arguments, "advertiseSet").value_or(true)) {
+            auto timeout = ReadInt(arguments, "timeout").value_or(0);
+            advertise_timeout_ = std::chrono::milliseconds(
+                std::clamp<std::int64_t>(timeout, 0, kMaxAdvertiseTimeout.count()));
+        }
 
         // `manufacturerDataBytes` is the same payload as `manufacturerData`, sent as
         // a byte buffer rather than a list of ints.
@@ -407,6 +428,7 @@ namespace flutter_ble_peripheral {
         else if (method_call.method_name().compare("stop") == 0) {
             try {
                 advertisement_pending_ = false;
+                advertisement_token_++;
                 if (bluetoothLEPublisher) {
                     bluetoothLEPublisher.Advertisement().ManufacturerData().Clear();
                     bluetoothLEPublisher.Advertisement().ServiceUuids().Clear();
@@ -607,10 +629,40 @@ namespace flutter_ble_peripheral {
         advertisement_pending_ = false;
         try {
             bluetoothLEPublisher.Start();
+            ArmAdvertiseTimeout();
             return true;
         }
         catch (...) {
             return false;
+        }
+    }
+
+    void FlutterBlePeripheralPlugin::ArmAdvertiseTimeout() {
+        // Anything that starts or stops advertising takes a new token, so that a
+        // timeout left over from an earlier advertisement does not end this one.
+        advertisement_token_++;
+        if (advertise_timeout_ > std::chrono::milliseconds::zero()) {
+            StopAfterTimeout(advertise_timeout_, advertisement_token_);
+        }
+    }
+
+    winrt::fire_and_forget FlutterBlePeripheralPlugin::StopAfterTimeout(
+        std::chrono::milliseconds timeout, uint32_t token) {
+        auto alive = alive_;
+        co_await winrt::resume_after(timeout);
+        co_await ui_thread_;
+        if (!*alive || token != advertisement_token_) co_return;
+
+        try {
+            // The publisher reports the stop itself, which is what moves the state
+            // back to idle.
+            if (bluetoothLEPublisher &&
+                bluetoothLEPublisher.Status() == BluetoothLEAdvertisementPublisherStatus::Started) {
+                bluetoothLEPublisher.Stop();
+            }
+        }
+        catch (...) {
+            // Nothing useful to do; the advertisement stays up.
         }
     }
 
@@ -631,6 +683,7 @@ namespace flutter_ble_peripheral {
 
         advertisement_pending_ = false;
         bluetoothLEPublisher.Start();
+        ArmAdvertiseTimeout();
         return BluetoothPeripheralState::Ready;
     }
 

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -26,9 +26,6 @@
 #include <atomic>
 #include <map>
 #include <memory>
-#include <sstream>
-#include <algorithm>
-#include <iomanip>
 
 namespace flutter_ble_peripheral {
 
@@ -50,7 +47,7 @@ namespace flutter_ble_peripheral {
 
 
 
-    class FlutterBlePeripheralPlugin : public flutter::Plugin, public flutter::StreamHandler<flutter::EncodableValue> {
+    class FlutterBlePeripheralPlugin : public flutter::Plugin {
     public:
         static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
 
@@ -73,23 +70,11 @@ namespace flutter_ble_peripheral {
         // Builds the advertisement payload from the arguments Dart sent.
         void BuildAdvertisement(const EncodableMap& arguments);
 
-        std::unique_ptr<flutter::StreamHandlerError<>> OnListenInternal(
-            const flutter::EncodableValue* arguments,
-            std::unique_ptr<flutter::EventSink<>>&& events) override;
-        std::unique_ptr<flutter::StreamHandlerError<>> OnCancelInternal(
-            const flutter::EncodableValue* arguments) override;
-
-        std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> scan_result_sink_;
         std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> state_changed_sink_;
 
         Radio bluetoothRadio{ nullptr };
         winrt::event_token radioStateChangedToken;
         winrt::fire_and_forget OnRadioStateChanged(Radio sender, IInspectable args);
-
-        BluetoothLEAdvertisementWatcher bluetoothLEWatcher{ nullptr };
-        winrt::event_token bluetoothLEWatcherReceivedToken;
-        winrt::fire_and_forget BluetoothLEWatcher_Received(BluetoothLEAdvertisementWatcher sender, BluetoothLEAdvertisementReceivedEventArgs args);
-
 
         BluetoothLEAdvertisementPublisher bluetoothLEPublisher{ nullptr };
         winrt::event_token bluetoothLEPublisherStatusChangedToken;

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -24,6 +24,7 @@
 #include "models/peripheral_state.h"
 
 #include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 
@@ -98,6 +99,11 @@ namespace flutter_ble_peripheral {
         // whether it went out; the publisher reports the resulting state itself.
         bool StartPendingAdvertisement();
 
+        // Starts the countdown that ends the advertisement just started, if the
+        // settings asked for one.
+        void ArmAdvertiseTimeout();
+        winrt::fire_and_forget StopAfterTimeout(std::chrono::milliseconds timeout, uint32_t token);
+
         // Starts the advertisement the publisher is holding, reporting the state it
         // leaves the peripheral in.
         BluetoothPeripheralState StartAdvertising();
@@ -107,6 +113,12 @@ namespace flutter_ble_peripheral {
         // Set when start() is called before the radio is up, so that the
         // advertisement can be issued once it comes on rather than being dropped.
         bool advertisement_pending_ = false;
+
+        // How long the advertisement runs for, or zero to leave it up.
+        std::chrono::milliseconds advertise_timeout_{ 0 };
+
+        // Identifies the advertisement a pending timeout belongs to.
+        uint32_t advertisement_token_ = 0;
 
         // Cleared when the plugin is destroyed, so that a coroutine resuming after
         // the fact does not touch it.


### PR DESCRIPTION
## Description

Advertising on Windows ran until it was stopped by hand, where Android ends it once `AdvertiseSettings.timeout` expires, so an app written against Android kept broadcasting indefinitely. Windows follows the same rule now, including the parts that are easy to miss: the timeout only applies when `advertiseSet` is false, since an advertising set is limited by its own duration instead, and zero leaves the advertisement up. A start or a stop invalidates a countdown still pending from an earlier advertisement. `timeout` is documented as Android only, which is no longer true.

Also drops the scan result event channel and the advertisement watcher behind it. Nothing ever created the watcher, no other platform registers the channel, and Dart never listened to it.

Checked against a real radio: with the default settings the advertisement stays up, `advertiseSet: false` with a 2000ms timeout stopped after 2018ms and moved the state stream back to idle, zero stays up, and an advertisement started after a stop is not cut short by the countdown the stopped one had.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
