### PR TITLE
fix: send the android advertising results from the main thread

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingCallback.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingCallback.kt
@@ -2,6 +2,8 @@ package dev.steenbakker.flutter_ble_peripheral.callbacks
 
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseSettings
+import android.os.Handler
+import android.os.Looper
 import dev.steenbakker.flutter_ble_peripheral.handlers.StateChangedHandler
 import dev.steenbakker.flutter_ble_peripheral.models.PeripheralState
 import dev.steenbakker.flutter_ble_peripheral.models.State
@@ -12,7 +14,11 @@ class PeripheralAdvertisingCallback(private val result: MethodChannel.Result, pr
     override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
         super.onStartSuccess(settingsInEffect)
         Log.i("FlutterBlePeripheral", "onStartSuccess() mode: ${settingsInEffect.mode}, txPOWER ${settingsInEffect.txPowerLevel}")
-        result.success(State.Ready.ordinal)
+        // The thread this callback arrives on is not part of the contract, and a
+        // result may only be sent from the main thread.
+        Handler(Looper.getMainLooper()).post {
+            result.success(State.Ready.ordinal)
+        }
         stateChangedHandler.publishPeripheralState(PeripheralState.advertising)
     }
 
@@ -46,6 +52,8 @@ class PeripheralAdvertisingCallback(private val result: MethodChannel.Result, pr
                 stateChangedHandler.publishPeripheralState(PeripheralState.unknown)
             }
         }
-        result.error(errorCode.toString(), statusText, "startAdvertising")
+        Handler(Looper.getMainLooper()).post {
+            result.error(errorCode.toString(), statusText, "startAdvertising")
+        }
     }
 }

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingSetCallback.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/PeripheralAdvertisingSetCallback.kt
@@ -4,6 +4,8 @@ import android.bluetooth.le.AdvertisingSet
 import android.bluetooth.le.AdvertisingSetCallback
 import android.bluetooth.le.BluetoothLeAdvertiser
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.RequiresApi
 import dev.steenbakker.flutter_ble_peripheral.handlers.StateChangedHandler
 import dev.steenbakker.flutter_ble_peripheral.models.PeripheralState
@@ -62,12 +64,16 @@ class PeripheralAdvertisingSetCallback(private val result: MethodChannel.Result,
             }
 
         }
-        if (status != ADVERTISE_SUCCESS) {
-            result.error(status.toString(), statusText, "startAdvertisingSet")
-        } else {
-            result.success(State.Ready.ordinal)
+        // The thread this callback arrives on is not part of the contract, and a
+        // result may only be sent from the main thread.
+        val message = statusText
+        Handler(Looper.getMainLooper()).post {
+            if (status != ADVERTISE_SUCCESS) {
+                result.error(status.toString(), message, "startAdvertisingSet")
+            } else {
+                result.success(State.Ready.ordinal)
+            }
         }
-
     }
 
     /**


### PR DESCRIPTION
## Description

`PeripheralAdvertisingCallback` and `PeripheralAdvertisingSetCallback` answered the method call straight from whatever thread the framework called them on, where everything else in the plugin posts to the main looper first. `BluetoothLeAdvertiser` does deliver these on the main thread today, so this is not a live bug, but it is not part of the `AdvertiseCallback` contract and it was the only place left relying on that.

One ordering change worth knowing: on a failed start the state now reaches the stream before the method call fails, rather than after, since `publishPeripheralState` was already posting and the error no longer jumps the queue.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
