### PR TITLE
feat(windows): serve a gatt server with tx and rx characteristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ platform carries all of them:
   about 10 bytes.
 - Android ignores `localName`; use `AndroidAdvertiseData.includeDeviceName` to
   broadcast the system name instead.
-- Windows carries only the manufacturer data and the service data. A legacy Windows
+- Windows carries only the manufacturer data and the service data, one of which has
+  to be set unless a `gattServer` is served alongside it. A legacy Windows
   advertisement refuses to start at all when it sets a local name or service uuids,
   so both are validated and then left off the air.
 
@@ -220,7 +221,11 @@ sent last.
 
 On Windows the service is advertised by the GATT service provider rather than by the
 advertisement publisher, which is also what makes the peripheral connectable there and
-puts the service uuid on air; a legacy Windows advertisement cannot carry one.
+puts the service uuid on air; a legacy Windows advertisement cannot carry one. Because
+the service carries itself, this is also the one case where Windows accepts an
+advertisement without manufacturer data or service data. The advertise timeout ends
+what the service has on air along with the publisher, leaving it serving whoever is
+already connected, the same as an Android advertise timeout does.
 
 ### Streams
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ when it can deliver. Payloads are queued per central, so back-to-back calls arri
 order rather than overwriting each other, and a central that reads TX gets the payload
 sent last.
 
-Not supported on Windows yet.
+On Windows the service is advertised by the GATT service provider rather than by the
+advertisement publisher, which is also what makes the peripheral connectable there and
+puts the service uuid on air; a legacy Windows advertisement cannot carry one.
 
 ### Streams
 

--- a/example/README.md
+++ b/example/README.md
@@ -90,7 +90,7 @@ await FlutterBlePeripheral().sendData(Uint8List.fromList([1, 2, 3]));
 | Android | yes | yes |
 | iOS | yes | yes |
 | macOS | yes | yes |
-| Windows | yes | not yet |
+| Windows | yes | yes |
 
 ## Notes
 
@@ -101,6 +101,8 @@ await FlutterBlePeripheral().sendData(Uint8List.fromList([1, 2, 3]));
   late can still pick it up.
 - Several centrals can connect at once. The example is written around a single
   one, but `sendData` notifies every subscriber.
-- On iOS and macOS `isConnected` is approximate: CoreBluetooth never reports a
-  bare connection, so a central only becomes visible once it subscribes, reads
-  or writes.
+- Only Android answers `isConnected` exactly. On iOS and macOS a central becomes
+  visible once it subscribes, reads or writes, since CoreBluetooth never reports
+  a bare connection; on Windows it is the same answer as `isSubscribed`.
+- Windows advertises the service through the GATT service provider rather than
+  the advertisement publisher, which is also what makes it connectable there.

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -234,9 +234,10 @@ class FlutterBlePeripheral {
   /// This is not the same as being able to send: a central has to subscribe
   /// before it can be notified, which is what [isSubscribed] reports.
   ///
-  /// On iOS and macOS this is approximate. CoreBluetooth never reports a bare
-  /// connection, so a central only becomes visible once it subscribes, reads or
-  /// writes.
+  /// Only Android answers this exactly. CoreBluetooth never reports a bare
+  /// connection, so on iOS and macOS a central becomes visible once it
+  /// subscribes, reads or writes. Windows reports subscribers only, so there
+  /// this is the same answer as [isSubscribed].
   Future<bool> get isConnected async =>
       await _methodChannel.invokeMethod<bool>('isConnected') ?? false;
 

--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -369,7 +369,8 @@ namespace flutter_ble_peripheral {
     // service uuids, whether through the properties or as data sections of their
     // own. Both are still validated, so that a malformed uuid is reported the way
     // Android and Apple report it, but neither reaches the air.
-    void FlutterBlePeripheralPlugin::BuildAdvertisement(const EncodableMap& arguments) {
+    bool FlutterBlePeripheralPlugin::BuildAdvertisement(
+        const EncodableMap& arguments, bool serving_gatt) {
         auto advertisement = bluetoothLEPublisher.Advertisement();
 
         // Rebuild from scratch, so repeated calls do not stack up.
@@ -444,15 +445,18 @@ namespace flutter_ble_peripheral {
         }
 
         // The publisher fails to start on an empty payload, with an error that says
-        // nothing about why.
-        if (advertisement.ManufacturerData().Size() == 0 &&
-            advertisement.DataSections().Size() == 0) {
+        // nothing about why. A GATT service advertises itself, so with one there is
+        // still something on air and the publisher is simply left alone.
+        bool has_payload = advertisement.ManufacturerData().Size() > 0 ||
+            advertisement.DataSections().Size() > 0;
+        if (!has_payload && !serving_gatt) {
             throw InvalidArgument(
                 "Windows can only advertise manufacturerData and serviceData, "
                 "one of which has to be set");
         }
 
         ApplyWindowsSettings(arguments);
+        return has_payload;
     }
 
     // The WindowsAdvertiseSettings fields, which sit on the publisher rather than
@@ -507,21 +511,21 @@ namespace flutter_ble_peripheral {
      * way to put a service uuid on air here and be connectable, since the
      * publisher refuses a legacy advertisement carrying one.
      */
-    winrt::fire_and_forget FlutterBlePeripheralPlugin::StartGattServer(
-        const std::string& service_uuid,
-        const std::string& tx_uuid,
-        const std::string& rx_uuid) {
-        auto service_guid = ParseServiceUuid(service_uuid).guid;
-        auto tx_guid = ParseServiceUuid(tx_uuid).guid;
-        auto rx_guid = ParseServiceUuid(rx_uuid).guid;
+    IAsyncOperation<bool> FlutterBlePeripheralPlugin::CreateGattServer(
+        uint32_t token,
+        winrt::guid service_uuid,
+        winrt::guid tx_uuid,
+        winrt::guid rx_uuid) {
+        auto lifetime = alive_;
 
-        StopGattServer();
-
-        auto provider_result = co_await GattServiceProvider::CreateAsync(service_guid);
+        // Built into locals and only committed to the plugin once it is whole, so
+        // that a stop or a teardown arriving while this is in flight leaves nothing
+        // half-served behind.
+        auto provider_result = co_await GattServiceProvider::CreateAsync(service_uuid);
         if (provider_result.Error() != BluetoothError::Success) {
-            co_return;
+            co_return false;
         }
-        gatt_provider_ = provider_result.ServiceProvider();
+        auto provider = provider_result.ServiceProvider();
 
         // TX: what sendData notifies on. Read as well, so a central that
         // subscribes late can still pick up the payload sent last.
@@ -532,13 +536,12 @@ namespace flutter_ble_peripheral {
             GattCharacteristicProperties::Indicate);
         tx_parameters.ReadProtectionLevel(GattProtectionLevel::Plain);
 
-        auto tx_result = co_await gatt_provider_.Service()
-            .CreateCharacteristicAsync(tx_guid, tx_parameters);
+        auto tx_result =
+            co_await provider.Service().CreateCharacteristicAsync(tx_uuid, tx_parameters);
         if (tx_result.Error() != BluetoothError::Success) {
-            StopGattServer();
-            co_return;
+            co_return false;
         }
-        gatt_tx_ = tx_result.Characteristic();
+        auto tx = tx_result.Characteristic();
 
         // RX: what a central writes to.
         GattLocalCharacteristicParameters rx_parameters;
@@ -547,13 +550,21 @@ namespace flutter_ble_peripheral {
             GattCharacteristicProperties::WriteWithoutResponse);
         rx_parameters.WriteProtectionLevel(GattProtectionLevel::Plain);
 
-        auto rx_result = co_await gatt_provider_.Service()
-            .CreateCharacteristicAsync(rx_guid, rx_parameters);
+        auto rx_result =
+            co_await provider.Service().CreateCharacteristicAsync(rx_uuid, rx_parameters);
         if (rx_result.Error() != BluetoothError::Success) {
-            StopGattServer();
-            co_return;
+            co_return false;
         }
-        gatt_rx_ = rx_result.Characteristic();
+        auto rx = rx_result.Characteristic();
+
+        // The plugin is only touched on the UI thread, and only while it is still
+        // the service this start was asked for.
+        co_await ui_thread_;
+        if (!lifetime->load() || token != gatt_token_) co_return false;
+
+        gatt_provider_ = provider;
+        gatt_tx_ = tx;
+        gatt_rx_ = rx;
 
         gatt_read_token_ = gatt_tx_.ReadRequested(
             { this, &FlutterBlePeripheralPlugin::OnReadRequested });
@@ -566,9 +577,74 @@ namespace flutter_ble_peripheral {
         advertising_parameters.IsConnectable(true);
         advertising_parameters.IsDiscoverable(true);
         gatt_provider_.StartAdvertising(advertising_parameters);
+        gatt_advertising_ = true;
+        co_return true;
+    }
+
+    winrt::fire_and_forget FlutterBlePeripheralPlugin::StartGattServerAndAdvertise(
+        std::shared_ptr<std::unique_ptr<flutter::MethodResult<EncodableValue>>> result) {
+        auto lifetime = alive_;
+        auto request = *gatt_request_;
+
+        StopGattServer();
+        auto token = ++gatt_token_;
+
+        bool served = false;
+        try {
+            served = co_await CreateGattServer(
+                token, request.service_uuid, request.tx_uuid, request.rx_uuid);
+        }
+        catch (...) {
+            // A coroutine that lets an exception escape takes the process with it,
+            // so a radio that fails mid-build is reported instead.
+            served = false;
+        }
+
+        co_await ui_thread_;
+        if (!lifetime->load()) co_return;
+
+        // There is no result to answer when the radio came up on its own and the
+        // held advertisement is being issued rather than a start() waiting on it.
+        auto* answer = (result && *result) ? result->get() : nullptr;
+
+        // A stop or a newer start arrived while this one was still building. What
+        // it left behind is not this call's to undo, so only the answer is left.
+        if (token != gatt_token_) {
+            if (answer) {
+                if (gatt_request_) {
+                    // A newer start took over and answers its own caller.
+                    answer->Success(static_cast<int>(BluetoothPeripheralState::Ready));
+                }
+                else {
+                    answer->Error(
+                        "start_cancelled", "Stopped before the GATT service came up");
+                }
+            }
+            co_return;
+        }
+
+        if (!served) {
+            StopGattServer();
+            gatt_request_.reset();
+            if (answer) answer->Error("start_failed", "Failed to serve the GATT service");
+            co_return;
+        }
+
+        try {
+            auto state = StartAdvertising();
+            if (answer) answer->Success(static_cast<int>(state));
+        }
+        catch (...) {
+            StopGattServer();
+            gatt_request_.reset();
+            if (answer) answer->Error("start_failed", "Failed to start advertising");
+        }
     }
 
     void FlutterBlePeripheralPlugin::StopGattServer() {
+        // Anything still being built belongs to an earlier start, and must not
+        // come up behind this.
+        gatt_token_++;
         if (gatt_tx_) {
             gatt_tx_.ReadRequested(gatt_read_token_);
             gatt_tx_.SubscribedClientsChanged(gatt_subscribers_token_);
@@ -584,10 +660,14 @@ namespace flutter_ble_peripheral {
                 // Already stopped, or the radio went away underneath it.
             }
         }
+        gatt_advertising_ = false;
         gatt_provider_ = nullptr;
         gatt_tx_ = nullptr;
         gatt_rx_ = nullptr;
-        gatt_last_sent_.clear();
+        {
+            std::lock_guard<std::mutex> guard(gatt_last_sent_mutex_);
+            gatt_last_sent_.clear();
+        }
         if (gatt_subscribed_) {
             gatt_subscribed_ = false;
             if (subscription_sink_) subscription_sink_->Success(EncodableValue(false));
@@ -602,15 +682,24 @@ namespace flutter_ble_peripheral {
         auto request = co_await args.GetRequestAsync();
         if (request && lifetime->load()) {
             // A value longer than the MTU is fetched in pieces, each with a
-            // larger offset, so only the tail is answered each time.
+            // larger offset, so only the tail is answered each time. This runs off
+            // the UI thread, where sendData replaces the payload, so the tail is
+            // taken under the lock rather than answered from the payload itself.
             auto offset = static_cast<size_t>(request.Offset());
-            if (offset > gatt_last_sent_.size()) {
+            std::optional<std::vector<uint8_t>> tail;
+            {
+                std::lock_guard<std::mutex> guard(gatt_last_sent_mutex_);
+                if (offset <= gatt_last_sent_.size()) {
+                    tail.emplace(gatt_last_sent_.begin() + offset, gatt_last_sent_.end());
+                }
+            }
+
+            if (!tail) {
                 request.RespondWithProtocolError(GattProtocolError::InvalidOffset());
             }
             else {
                 DataWriter writer;
-                writer.WriteBytes(std::vector<uint8_t>(
-                    gatt_last_sent_.begin() + offset, gatt_last_sent_.end()));
+                writer.WriteBytes(*tail);
                 request.RespondWithValue(writer.DetachBuffer());
             }
         }
@@ -688,13 +777,14 @@ namespace flutter_ble_peripheral {
                     return;
                 }
 
-                BuildAdvertisement(*arguments);
-
                 // A Windows GATT service advertises itself, separately from the
                 // publisher, and that is also what makes the peripheral
-                // connectable and puts the service uuid on air.
-                auto service_uuid = ReadString(*arguments, "gattServiceUuid");
-                if (service_uuid) {
+                // connectable and puts the service uuid on air. The uuids are
+                // parsed here rather than where the service is built, since that
+                // runs as a coroutine, where a throw would take the process down
+                // instead of reaching Dart.
+                gatt_request_.reset();
+                if (auto service_uuid = ReadString(*arguments, "gattServiceUuid")) {
                     auto tx = ReadString(*arguments, "gattTxCharacteristicUuid");
                     auto rx = ReadString(*arguments, "gattRxCharacteristicUuid");
                     if (!tx || !rx) {
@@ -702,15 +792,35 @@ namespace flutter_ble_peripheral {
                             "gattServiceUuid needs a gattTxCharacteristicUuid and a "
                             "gattRxCharacteristicUuid");
                     }
-                    StartGattServer(*service_uuid, *tx, *rx);
+                    gatt_request_ = GattRequest{
+                        ParseServiceUuid(*service_uuid).guid,
+                        ParseServiceUuid(*tx).guid,
+                        ParseServiceUuid(*rx).guid,
+                    };
                 }
 
+                advertisement_has_payload_ =
+                    BuildAdvertisement(*arguments, gatt_request_.has_value());
+
+                // Nothing can be served while the radio is down; the service comes
+                // up with the held advertisement once it is back.
+                if (gatt_request_ && bluetoothRadio &&
+                    bluetoothRadio.State() == RadioState::On) {
+                    auto shared = std::make_shared<
+                        std::unique_ptr<flutter::MethodResult<EncodableValue>>>(std::move(result));
+                    StartGattServerAndAdvertise(shared);
+                    return;
+                }
+
+                StopGattServer();
                 result->Success(static_cast<int>(StartAdvertising()));
             }
             catch (const InvalidArgument& error) {
+                gatt_request_.reset();
                 result->Error("invalid_arguments", error.what());
             }
             catch (...) {
+                gatt_request_.reset();
                 result->Error("start_failed", "Failed to start advertising");
             }
         }
@@ -718,6 +828,7 @@ namespace flutter_ble_peripheral {
             try {
                 advertisement_pending_ = false;
                 advertisement_token_++;
+                gatt_request_.reset();
                 if (bluetoothLEPublisher) {
                     bluetoothLEPublisher.Advertisement().ManufacturerData().Clear();
                     bluetoothLEPublisher.Advertisement().ServiceUuids().Clear();
@@ -726,6 +837,11 @@ namespace flutter_ble_peripheral {
                     bluetoothLEPublisher.Stop();
                 }
                 StopGattServer();
+                if (!advertisement_has_payload_) {
+                    // Nothing was on the publisher to report its own stop.
+                    PublishState(PeripheralState::Idle);
+                }
+                advertisement_has_payload_ = false;
                 result->Success(static_cast<int>(BluetoothPeripheralState::Ready));
             }
             catch (...) {
@@ -734,8 +850,12 @@ namespace flutter_ble_peripheral {
         } else if (method_call.method_name().compare("isAdvertising") == 0) {
             bool isAdvertising = false;
             try {
-                isAdvertising = bluetoothLEPublisher &&
-                    bluetoothLEPublisher.Status() == BluetoothLEAdvertisementPublisherStatus::Started;
+                // A GATT service is advertised by its own provider, so with one
+                // there can be something on air without the publisher.
+                isAdvertising = gatt_advertising_ ||
+                    (bluetoothLEPublisher &&
+                        bluetoothLEPublisher.Status() ==
+                            BluetoothLEAdvertisementPublisherStatus::Started);
             }
             catch (...) {
                 isAdvertising = false;
@@ -784,7 +904,10 @@ namespace flutter_ble_peripheral {
                 return;
             }
             try {
-                gatt_last_sent_ = *bytes;
+                {
+                    std::lock_guard<std::mutex> guard(gatt_last_sent_mutex_);
+                    gatt_last_sent_ = *bytes;
+                }
                 DataWriter writer;
                 writer.WriteBytes(*bytes);
                 // Windows queues this itself, so there is no backpressure to
@@ -951,6 +1074,13 @@ namespace flutter_ble_peripheral {
 
         advertisement_pending_ = false;
         try {
+            // The service was held back with the advertisement, since nothing can
+            // be served while the radio is down. It issues the advertisement
+            // itself once it is up, with nobody left waiting on the answer.
+            if (gatt_request_) {
+                StartGattServerAndAdvertise(nullptr);
+                return true;
+            }
             bluetoothLEPublisher.Start();
             ArmAdvertiseTimeout();
             return true;
@@ -983,6 +1113,16 @@ namespace flutter_ble_peripheral {
                 bluetoothLEPublisher.Status() == BluetoothLEAdvertisementPublisherStatus::Started) {
                 bluetoothLEPublisher.Stop();
             }
+            // The service keeps serving whoever is already connected, the same as
+            // an Android advertise timeout leaves its GATT server up; only what is
+            // on air ends here.
+            if (gatt_provider_ && gatt_advertising_) {
+                gatt_provider_.StopAdvertising();
+                gatt_advertising_ = false;
+                if (!advertisement_has_payload_) {
+                    PublishState(PeripheralState::Idle);
+                }
+            }
         }
         catch (...) {
             // Nothing useful to do; the advertisement stays up.
@@ -1005,7 +1145,14 @@ namespace flutter_ble_peripheral {
         }
 
         advertisement_pending_ = false;
-        bluetoothLEPublisher.Start();
+        if (advertisement_has_payload_) {
+            bluetoothLEPublisher.Start();
+        }
+        else {
+            // Only the publisher reports its own status, so with the GATT service
+            // as the one thing on air the state is reported here instead.
+            PublishState(PeripheralState::Advertising);
+        }
         ArmAdvertiseTimeout();
         return BluetoothPeripheralState::Ready;
     }
@@ -1097,6 +1244,12 @@ namespace flutter_ble_peripheral {
 
             co_await ui_thread_;
             if (!*alive) co_return;
+
+            // A radio going down takes the service advertisement with it, which
+            // the provider does not report.
+            if (radioState != RadioState::On) {
+                gatt_advertising_ = false;
+            }
 
             if (!StartPendingAdvertisement()) {
                 PublishState(StateOf(radioState));

--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -76,7 +76,65 @@ namespace flutter_ble_peripheral {
                 });
         event_state_changed->SetStreamHandler(std::move(state_handler));
 
+        auto event_data_received =
+            std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
+                registrar->messenger(),
+                "dev.steenbakker.flutter_ble_peripheral/ble_data_received",
+                &flutter::StandardMethodCodec::GetInstance());
+        event_data_received->SetStreamHandler(
+            std::make_unique<flutter::StreamHandlerFunctions<>>(
+                [plugin_pointer = plugin.get()](
+                    const flutter::EncodableValue*,
+                    std::unique_ptr<flutter::EventSink<>>&& events)
+                -> std::unique_ptr<flutter::StreamHandlerError<>> {
+                    plugin_pointer->data_received_sink_ = std::move(events);
+                    return nullptr;
+                },
+                [plugin_pointer = plugin.get()](const flutter::EncodableValue*)
+                    -> std::unique_ptr<flutter::StreamHandlerError<>> {
+                    plugin_pointer->data_received_sink_ = nullptr;
+                    return nullptr;
+                }));
 
+        auto event_mtu_changed =
+            std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
+                registrar->messenger(),
+                "dev.steenbakker.flutter_ble_peripheral/ble_mtu_changed",
+                &flutter::StandardMethodCodec::GetInstance());
+        event_mtu_changed->SetStreamHandler(
+            std::make_unique<flutter::StreamHandlerFunctions<>>(
+                [plugin_pointer = plugin.get()](
+                    const flutter::EncodableValue*,
+                    std::unique_ptr<flutter::EventSink<>>&& events)
+                -> std::unique_ptr<flutter::StreamHandlerError<>> {
+                    plugin_pointer->mtu_changed_sink_ = std::move(events);
+                    return nullptr;
+                },
+                [plugin_pointer = plugin.get()](const flutter::EncodableValue*)
+                    -> std::unique_ptr<flutter::StreamHandlerError<>> {
+                    plugin_pointer->mtu_changed_sink_ = nullptr;
+                    return nullptr;
+                }));
+
+        auto event_subscription =
+            std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
+                registrar->messenger(),
+                "dev.steenbakker.flutter_ble_peripheral/ble_subscription_changed",
+                &flutter::StandardMethodCodec::GetInstance());
+        event_subscription->SetStreamHandler(
+            std::make_unique<flutter::StreamHandlerFunctions<>>(
+                [plugin_pointer = plugin.get()](
+                    const flutter::EncodableValue*,
+                    std::unique_ptr<flutter::EventSink<>>&& events)
+                -> std::unique_ptr<flutter::StreamHandlerError<>> {
+                    plugin_pointer->subscription_sink_ = std::move(events);
+                    return nullptr;
+                },
+                [plugin_pointer = plugin.get()](const flutter::EncodableValue*)
+                    -> std::unique_ptr<flutter::StreamHandlerError<>> {
+                    plugin_pointer->subscription_sink_ = nullptr;
+                    return nullptr;
+                }));
 
         registrar->AddPlugin(std::move(plugin));
     }
@@ -102,6 +160,9 @@ namespace flutter_ble_peripheral {
                     bluetoothLEPublisher.Stop();
                 }
             }
+            // Same reason: a read, write or subscription event arriving after
+            // this would run against a destroyed plugin.
+            StopGattServer();
         }
         catch (...) {
             // Nothing useful to do while tearing down.
@@ -435,6 +496,181 @@ namespace flutter_ble_peripheral {
         }
     }
 
+
+    // MARK: - GATT server
+
+    /**
+     * Serves the requested service and advertises it.
+     *
+     * A Windows GATT service advertises itself through the service provider
+     * rather than through the advertisement publisher, and that is also the only
+     * way to put a service uuid on air here and be connectable, since the
+     * publisher refuses a legacy advertisement carrying one.
+     */
+    winrt::fire_and_forget FlutterBlePeripheralPlugin::StartGattServer(
+        const std::string& service_uuid,
+        const std::string& tx_uuid,
+        const std::string& rx_uuid) {
+        auto service_guid = ParseServiceUuid(service_uuid).guid;
+        auto tx_guid = ParseServiceUuid(tx_uuid).guid;
+        auto rx_guid = ParseServiceUuid(rx_uuid).guid;
+
+        StopGattServer();
+
+        auto provider_result = co_await GattServiceProvider::CreateAsync(service_guid);
+        if (provider_result.Error() != BluetoothError::Success) {
+            co_return;
+        }
+        gatt_provider_ = provider_result.ServiceProvider();
+
+        // TX: what sendData notifies on. Read as well, so a central that
+        // subscribes late can still pick up the payload sent last.
+        GattLocalCharacteristicParameters tx_parameters;
+        tx_parameters.CharacteristicProperties(
+            GattCharacteristicProperties::Read |
+            GattCharacteristicProperties::Notify |
+            GattCharacteristicProperties::Indicate);
+        tx_parameters.ReadProtectionLevel(GattProtectionLevel::Plain);
+
+        auto tx_result = co_await gatt_provider_.Service()
+            .CreateCharacteristicAsync(tx_guid, tx_parameters);
+        if (tx_result.Error() != BluetoothError::Success) {
+            StopGattServer();
+            co_return;
+        }
+        gatt_tx_ = tx_result.Characteristic();
+
+        // RX: what a central writes to.
+        GattLocalCharacteristicParameters rx_parameters;
+        rx_parameters.CharacteristicProperties(
+            GattCharacteristicProperties::Write |
+            GattCharacteristicProperties::WriteWithoutResponse);
+        rx_parameters.WriteProtectionLevel(GattProtectionLevel::Plain);
+
+        auto rx_result = co_await gatt_provider_.Service()
+            .CreateCharacteristicAsync(rx_guid, rx_parameters);
+        if (rx_result.Error() != BluetoothError::Success) {
+            StopGattServer();
+            co_return;
+        }
+        gatt_rx_ = rx_result.Characteristic();
+
+        gatt_read_token_ = gatt_tx_.ReadRequested(
+            { this, &FlutterBlePeripheralPlugin::OnReadRequested });
+        gatt_subscribers_token_ = gatt_tx_.SubscribedClientsChanged(
+            { this, &FlutterBlePeripheralPlugin::OnSubscribersChanged });
+        gatt_write_token_ = gatt_rx_.WriteRequested(
+            { this, &FlutterBlePeripheralPlugin::OnWriteRequested });
+
+        GattServiceProviderAdvertisingParameters advertising_parameters;
+        advertising_parameters.IsConnectable(true);
+        advertising_parameters.IsDiscoverable(true);
+        gatt_provider_.StartAdvertising(advertising_parameters);
+    }
+
+    void FlutterBlePeripheralPlugin::StopGattServer() {
+        if (gatt_tx_) {
+            gatt_tx_.ReadRequested(gatt_read_token_);
+            gatt_tx_.SubscribedClientsChanged(gatt_subscribers_token_);
+        }
+        if (gatt_rx_) {
+            gatt_rx_.WriteRequested(gatt_write_token_);
+        }
+        if (gatt_provider_) {
+            try {
+                gatt_provider_.StopAdvertising();
+            }
+            catch (...) {
+                // Already stopped, or the radio went away underneath it.
+            }
+        }
+        gatt_provider_ = nullptr;
+        gatt_tx_ = nullptr;
+        gatt_rx_ = nullptr;
+        gatt_last_sent_.clear();
+        if (gatt_subscribed_) {
+            gatt_subscribed_ = false;
+            if (subscription_sink_) subscription_sink_->Success(EncodableValue(false));
+        }
+    }
+
+    winrt::fire_and_forget FlutterBlePeripheralPlugin::OnReadRequested(
+        GattLocalCharacteristic const&,
+        GattReadRequestedEventArgs const& args) {
+        auto lifetime = alive_;
+        auto deferral = args.GetDeferral();
+        auto request = co_await args.GetRequestAsync();
+        if (request && lifetime->load()) {
+            // A value longer than the MTU is fetched in pieces, each with a
+            // larger offset, so only the tail is answered each time.
+            auto offset = static_cast<size_t>(request.Offset());
+            if (offset > gatt_last_sent_.size()) {
+                request.RespondWithProtocolError(GattProtocolError::InvalidOffset());
+            }
+            else {
+                DataWriter writer;
+                writer.WriteBytes(std::vector<uint8_t>(
+                    gatt_last_sent_.begin() + offset, gatt_last_sent_.end()));
+                request.RespondWithValue(writer.DetachBuffer());
+            }
+        }
+        deferral.Complete();
+    }
+
+    winrt::fire_and_forget FlutterBlePeripheralPlugin::OnWriteRequested(
+        GattLocalCharacteristic const&,
+        GattWriteRequestedEventArgs const& args) {
+        auto lifetime = alive_;
+        auto deferral = args.GetDeferral();
+        auto request = co_await args.GetRequestAsync();
+        if (request) {
+            auto reader = DataReader::FromBuffer(request.Value());
+            std::vector<uint8_t> bytes(reader.UnconsumedBufferLength());
+            reader.ReadBytes(bytes);
+
+            if (request.Option() == GattWriteOption::WriteWithResponse) {
+                request.Respond();
+            }
+
+            co_await ui_thread_;
+            if (lifetime->load() && data_received_sink_ && !bytes.empty()) {
+                data_received_sink_->Success(EncodableValue(bytes));
+            }
+        }
+        deferral.Complete();
+    }
+
+    winrt::fire_and_forget FlutterBlePeripheralPlugin::OnSubscribersChanged(
+        GattLocalCharacteristic const& characteristic,
+        winrt::Windows::Foundation::IInspectable const&) {
+        auto lifetime = alive_;
+        auto clients = characteristic.SubscribedClients();
+        bool subscribed = clients.Size() > 0;
+
+        // The MTU is per client; the smallest is what a notification to all of
+        // them has to fit in.
+        int mtu = 0;
+        for (auto const& client : clients) {
+            auto size = static_cast<int>(client.MaxNotificationSize());
+            if (mtu == 0 || size < mtu) mtu = size;
+        }
+
+        co_await ui_thread_;
+        if (!lifetime->load()) co_return;
+
+        if (subscribed != gatt_subscribed_) {
+            gatt_subscribed_ = subscribed;
+            if (subscription_sink_) {
+                subscription_sink_->Success(EncodableValue(subscribed));
+            }
+        }
+        // Windows reports the payload size; Dart reports the MTU, which is three
+        // bytes larger for the ATT header, matching what Android sends.
+        if (mtu > 0 && mtu_changed_sink_) {
+            mtu_changed_sink_->Success(EncodableValue(mtu + 3));
+        }
+    }
+
     void FlutterBlePeripheralPlugin::HandleMethodCall(
         const flutter::MethodCall<flutter::EncodableValue>& method_call,
         std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
@@ -453,6 +689,22 @@ namespace flutter_ble_peripheral {
                 }
 
                 BuildAdvertisement(*arguments);
+
+                // A Windows GATT service advertises itself, separately from the
+                // publisher, and that is also what makes the peripheral
+                // connectable and puts the service uuid on air.
+                auto service_uuid = ReadString(*arguments, "gattServiceUuid");
+                if (service_uuid) {
+                    auto tx = ReadString(*arguments, "gattTxCharacteristicUuid");
+                    auto rx = ReadString(*arguments, "gattRxCharacteristicUuid");
+                    if (!tx || !rx) {
+                        throw InvalidArgument(
+                            "gattServiceUuid needs a gattTxCharacteristicUuid and a "
+                            "gattRxCharacteristicUuid");
+                    }
+                    StartGattServer(*service_uuid, *tx, *rx);
+                }
+
                 result->Success(static_cast<int>(StartAdvertising()));
             }
             catch (const InvalidArgument& error) {
@@ -473,6 +725,7 @@ namespace flutter_ble_peripheral {
                     bluetoothLEPublisher.Advertisement().LocalName(L"");
                     bluetoothLEPublisher.Stop();
                 }
+                StopGattServer();
                 result->Success(static_cast<int>(BluetoothPeripheralState::Ready));
             }
             catch (...) {
@@ -507,8 +760,41 @@ namespace flutter_ble_peripheral {
             result->Success(isOn);
         }
         else if (method_call.method_name().compare("isConnected") == 0) {
-            // Windows has no GATT server yet, so nothing can be connected to it.
-            result->Success(false);
+            // Windows reports subscribers rather than connections, so this is the
+            // same answer as isSubscribed. Documented as such on the Dart side.
+            result->Success(gatt_tx_ ? gatt_tx_.SubscribedClients().Size() > 0 : false);
+        }
+        else if (method_call.method_name().compare("isSubscribed") == 0) {
+            result->Success(gatt_tx_ ? gatt_tx_.SubscribedClients().Size() > 0 : false);
+        }
+        else if (method_call.method_name().compare("sendData") == 0) {
+            if (!gatt_tx_) {
+                result->Error("NOT_INITIALIZED", "No GATT server is running");
+                return;
+            }
+            const auto* bytes = std::get_if<std::vector<uint8_t>>(method_call.arguments());
+            if (!bytes) {
+                result->Error("INVALID_ARGUMENT", "Data must be a byte array");
+                return;
+            }
+            if (gatt_tx_.SubscribedClients().Size() == 0) {
+                result->Error(
+                    "SEND_FAILED",
+                    "No central is subscribed to the TX characteristic");
+                return;
+            }
+            try {
+                gatt_last_sent_ = *bytes;
+                DataWriter writer;
+                writer.WriteBytes(*bytes);
+                // Windows queues this itself, so there is no backpressure to
+                // handle the way Android and Apple need it.
+                gatt_tx_.NotifyValueAsync(writer.DetachBuffer());
+                result->Success();
+            }
+            catch (...) {
+                result->Error("SEND_FAILED", "Failed to notify the subscribed centrals");
+            }
         }
         else if (method_call.method_name().compare("openAppSettings") == 0) {
             // A Flutter app on Windows is unpackaged and has no settings page of

--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -641,6 +641,20 @@ namespace flutter_ble_peripheral {
         }
     }
 
+    bool FlutterBlePeripheralPlugin::IsAdvertising() const {
+        try {
+            // A GATT service is advertised by its own provider, so with one there
+            // can be something on air without the publisher.
+            return gatt_advertising_ ||
+                (bluetoothLEPublisher &&
+                    bluetoothLEPublisher.Status() ==
+                        BluetoothLEAdvertisementPublisherStatus::Started);
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
     void FlutterBlePeripheralPlugin::StopGattServer() {
         // Anything still being built belongs to an earlier start, and must not
         // come up behind this.
@@ -752,6 +766,14 @@ namespace flutter_ble_peripheral {
             if (subscription_sink_) {
                 subscription_sink_->Success(EncodableValue(subscribed));
             }
+            // Windows reports subscribers and never a bare connection, so a
+            // subscription is as close as it gets to one, the way Apple reports it.
+            if (subscribed) {
+                PublishState(PeripheralState::Connected);
+            }
+            else if (IsAdvertising()) {
+                PublishState(PeripheralState::Advertising);
+            }
         }
         // Windows reports the payload size; Dart reports the MTU, which is three
         // bytes larger for the ATT header, matching what Android sends.
@@ -848,19 +870,7 @@ namespace flutter_ble_peripheral {
                 result->Error("stop_failed", "Failed to stop advertising");
             }
         } else if (method_call.method_name().compare("isAdvertising") == 0) {
-            bool isAdvertising = false;
-            try {
-                // A GATT service is advertised by its own provider, so with one
-                // there can be something on air without the publisher.
-                isAdvertising = gatt_advertising_ ||
-                    (bluetoothLEPublisher &&
-                        bluetoothLEPublisher.Status() ==
-                            BluetoothLEAdvertisementPublisherStatus::Started);
-            }
-            catch (...) {
-                isAdvertising = false;
-            }
-            result->Success(isAdvertising);
+            result->Success(IsAdvertising());
         }
         else if (method_call.method_name().compare("isSupported") == 0) {
             bool supported = bluetoothRadio != nullptr &&

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -98,6 +98,9 @@ namespace flutter_ble_peripheral {
         winrt::fire_and_forget StartGattServerAndAdvertise(
             std::shared_ptr<std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>> result);
 
+        // Whether anything is on air, from either the publisher or the service.
+        bool IsAdvertising() const;
+
         // Tears the GATT service down and stops advertising it.
         void StopGattServer();
 

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -25,6 +25,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <string>
+#include <vector>
 #include <map>
 #include <memory>
 
@@ -74,6 +76,49 @@ namespace flutter_ble_peripheral {
         // Applies the WindowsAdvertiseSettings fields, which sit on the publisher
         // rather than on the advertisement.
         void ApplyWindowsSettings(const EncodableMap& arguments);
+
+        // Serves the GATT service Dart asked for, with its TX and RX
+        // characteristics, and advertises it as connectable.
+        winrt::fire_and_forget StartGattServer(
+            const std::string& service_uuid,
+            const std::string& tx_uuid,
+            const std::string& rx_uuid);
+
+        // Tears the GATT service down and stops advertising it.
+        void StopGattServer();
+
+        // Hands a central the value sendData sent last.
+        winrt::fire_and_forget OnReadRequested(
+            GattLocalCharacteristic const& characteristic,
+            GattReadRequestedEventArgs const& args);
+
+        // Forwards what a central wrote to the RX characteristic to Dart.
+        winrt::fire_and_forget OnWriteRequested(
+            GattLocalCharacteristic const& characteristic,
+            GattWriteRequestedEventArgs const& args);
+
+        // Reports whether any central is subscribed, and the MTU it negotiated.
+        winrt::fire_and_forget OnSubscribersChanged(
+            GattLocalCharacteristic const& characteristic,
+            winrt::Windows::Foundation::IInspectable const& args);
+
+        std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> data_received_sink_;
+        std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> mtu_changed_sink_;
+        std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> subscription_sink_;
+
+        GattServiceProvider gatt_provider_{ nullptr };
+        GattLocalCharacteristic gatt_tx_{ nullptr };
+        GattLocalCharacteristic gatt_rx_{ nullptr };
+        winrt::event_token gatt_read_token_;
+        winrt::event_token gatt_write_token_;
+        winrt::event_token gatt_subscribers_token_;
+
+        // The payload sendData was given last, handed back to a central that
+        // reads the TX characteristic.
+        std::vector<uint8_t> gatt_last_sent_;
+
+        // The last subscription state published, so only changes are sent.
+        bool gatt_subscribed_ = false;
 
         std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> state_changed_sink_;
 

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -29,6 +29,8 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <optional>
 
 namespace flutter_ble_peripheral {
 
@@ -70,19 +72,31 @@ namespace flutter_ble_peripheral {
             const flutter::MethodCall<flutter::EncodableValue>& method_call,
             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
-        // Builds the advertisement payload from the arguments Dart sent.
-        void BuildAdvertisement(const EncodableMap& arguments);
+        // Builds the advertisement payload from the arguments Dart sent, and
+        // reports whether the publisher ended up with anything to carry. It can
+        // come out empty only when a GATT service is served alongside it, which
+        // puts itself on air.
+        bool BuildAdvertisement(const EncodableMap& arguments, bool serving_gatt);
 
         // Applies the WindowsAdvertiseSettings fields, which sit on the publisher
         // rather than on the advertisement.
         void ApplyWindowsSettings(const EncodableMap& arguments);
 
         // Serves the GATT service Dart asked for, with its TX and RX
-        // characteristics, and advertises it as connectable.
-        winrt::fire_and_forget StartGattServer(
-            const std::string& service_uuid,
-            const std::string& tx_uuid,
-            const std::string& rx_uuid);
+        // characteristics, and advertises it as connectable. Reports whether it
+        // came up.
+        IAsyncOperation<bool> CreateGattServer(
+            uint32_t token,
+            winrt::guid service_uuid,
+            winrt::guid tx_uuid,
+            winrt::guid rx_uuid);
+
+        // Serves the requested GATT service and then issues the advertisement,
+        // answering the start() that asked for both. The service has to be up
+        // before start() can report success, so the answer is deferred until it
+        // is rather than sent while it is still being built.
+        winrt::fire_and_forget StartGattServerAndAdvertise(
+            std::shared_ptr<std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>> result);
 
         // Tears the GATT service down and stops advertising it.
         void StopGattServer();
@@ -113,12 +127,32 @@ namespace flutter_ble_peripheral {
         winrt::event_token gatt_write_token_;
         winrt::event_token gatt_subscribers_token_;
 
+        // Whether the service is on air. Tracked here rather than read back from
+        // the provider, which goes on reporting Started after a StopAdvertising
+        // and whose AdvertisementStatusChanged arrives out of order.
+        bool gatt_advertising_ = false;
+
         // The payload sendData was given last, handed back to a central that
-        // reads the TX characteristic.
+        // reads the TX characteristic. A read is answered off the UI thread,
+        // where sendData replaces it, so it is guarded.
         std::vector<uint8_t> gatt_last_sent_;
+        std::mutex gatt_last_sent_mutex_;
 
         // The last subscription state published, so only changes are sent.
         bool gatt_subscribed_ = false;
+
+        // The service to serve, kept so that a start() held back while the radio
+        // was down still brings it up once the radio comes on.
+        struct GattRequest {
+            winrt::guid service_uuid;
+            winrt::guid tx_uuid;
+            winrt::guid rx_uuid;
+        };
+        std::optional<GattRequest> gatt_request_;
+
+        // Identifies the service a start still in flight is building, so that one
+        // finishing after a stop does not bring the service back up.
+        uint32_t gatt_token_ = 0;
 
         std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> state_changed_sink_;
 
@@ -154,7 +188,8 @@ namespace flutter_ble_peripheral {
         winrt::fire_and_forget StopAfterTimeout(std::chrono::milliseconds timeout, uint32_t token);
 
         // Starts the advertisement the publisher is holding, reporting the state it
-        // leaves the peripheral in.
+        // leaves the peripheral in. With nothing for the publisher to carry it only
+        // arms the timeout, the GATT service being what is on air.
         BluetoothPeripheralState StartAdvertising();
 
         PeripheralState peripheral_state_{ PeripheralState::Unknown };
@@ -162,6 +197,10 @@ namespace flutter_ble_peripheral {
         // Set when start() is called before the radio is up, so that the
         // advertisement can be issued once it comes on rather than being dropped.
         bool advertisement_pending_ = false;
+
+        // Whether the publisher has a payload to carry. False when the GATT
+        // service is the only thing being advertised.
+        bool advertisement_has_payload_ = false;
 
         // How long the advertisement runs for, or zero to leave it up.
         std::chrono::milliseconds advertise_timeout_{ 0 };


### PR DESCRIPTION
## Description

Stacked on #260, so review that first — the diff here is only the Windows side.

Windows now serves the same TX/RX pair Android and Apple do, so `sendData`, `onDataReceived`, `onMtuChanged`, `onSubscriptionChanged`, `isConnected` and `isSubscribed` work there rather than falling through to not-implemented.

The part that surprised me: on Windows the GATT service advertises *itself*, through
`GattServiceProvider.StartAdvertising` with `IsConnectable`, not through the
advertisement publisher. That is also the answer to something #297 ran into — a
legacy Windows advertisement refuses to start when it carries a service uuid, so
until now there was no way to put one on air here at all. Serving a service is that
way. The publisher keeps carrying the manufacturer and service data as before, and
the two run alongside each other. It is also the one case where the publisher is
allowed to carry nothing: a service uuid plus a `gattServer`, with no manufacturer
or service data, now starts rather than being refused by the empty payload check,
since the service is what is on air. `isAdvertising`, the state stream and the
advertise timeout all account for that. The timeout ends what the service has on
air and leaves it serving whoever is already connected, the way an Android
advertise timeout leaves its GATT server up.

Some smaller mappings:

`SubscribedClientsChanged` covers both the subscription state and the MTU, since
Windows reports `MaxNotificationSize` per client. The smallest across the subscribed
clients is what a notification has to fit in, so that is what gets reported, plus the
three byte ATT header so it lines up with what Android sends.

Reads honour the offset the same way, answering with the tail of the payload sent
last so a value longer than the MTU can be fetched in pieces. The payload sits behind
a lock, since a read is answered off the UI thread while `sendData` writes it on the
UI thread.

`isConnected` is the same answer as `isSubscribed` here, because Windows reports
subscribers and never a bare connection. Documented on the Dart getter, which now
describes what each of the three platforms actually answers.

There is no notify queue: `NotifyValueAsync` queues internally, so the backpressure
Android and Apple need does not apply.

Serving the service is asynchronous, so `start()` waits for it rather than answering
while it is still being built; a service that cannot be served is reported instead of
swallowed, and `sendData` straight after `start()` finds the server there. The uuids
are parsed before that coroutine starts, because an exception escaping a
`fire_and_forget` calls `winrt::terminate` and takes the process down instead of
reaching Dart — a malformed uuid used to kill the app.

Checked against a real radio on Windows 11: the service provider reports its
advertisement started, start/stop/restart cycles come up and go down cleanly, the
timeout ends the advertisement while the service keeps serving, and a start
superseded by another start or cancelled by a stop no longer tears down whatever
took over. There is no second device here, so nothing ever connected — subscription,
MTU, reads and writes are unproven on air.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.
