### PR TITLE
fix(windows): align the peripheral state values with the dart enum

### DIFF
--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -563,10 +563,6 @@ namespace flutter_ble_peripheral {
         }
     }
 
-    // PeripheralState enum values from Dart:
-    // 0: unknown, 1: unsupported, 2: unauthorized, 3: poweredOff,
-    // 4: idle, 5: advertising, 6: connected, 7: shouldShowRequestPermissionRationale
-
     winrt::fire_and_forget FlutterBlePeripheralPlugin::BluetoothLEPublisher_StatusChanged(
         BluetoothLEAdvertisementPublisher sender,
         BluetoothLEAdvertisementPublisherStatusChangedEventArgs args)

--- a/windows/models/peripheral_state.h
+++ b/windows/models/peripheral_state.h
@@ -11,10 +11,13 @@ namespace models {
         Unsupported = 1,
         Unauthorized = 2,
         PoweredOff = 3,
-        Idle = 4,
-        Advertising = 5,
-        Connected = 6,
-        ShouldShowRequestPermissionRationale = 7,
+        // Android only, and never published from here, but it sits in the middle
+        // of the Dart enum, so everything after it hangs off having it.
+        LocationServicesDisabled = 4,
+        Idle = 5,
+        Advertising = 6,
+        Connected = 7,
+        ShouldShowRequestPermissionRationale = 8,
     };
 
     // Mirrors the Dart `BluetoothPeripheralState`, which is what `start`, `stop`


### PR DESCRIPTION
## Description

The Windows `PeripheralState` enum never got `locationServicesDisabled`, which sits fourth in the Dart enum, so every value from `idle` on was one short. Since the state stream carries the index, Windows has been reporting `advertising` as `idle` and `idle` as `locationServicesDisabled` — an Android-only state that cannot happen there. The Kotlin and Swift enums both carry the entry already; only Windows was missing it.

Also drops the copy of the enum listing that sat above `BluetoothLEPublisher_StatusChanged`, which had drifted the same way. The header is the one place to keep in sync.

Checked against a real radio: the stream now reports `advertising` on start and `idle` on stop, where it used to report `idle` and `locationServicesDisabled`.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.