### PR TITLE
fix(apple): report the att mtu rather than the notification payload size

### DIFF
--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
@@ -114,8 +114,8 @@ extension FlutterBlePeripheralManager: CBPeripheralManagerDelegate {
 
         if characteristic.uuid == txCharacteristic?.uuid {
             // Update MTU
-            self.mtu = central.maximumUpdateValueLength
-            print("[flutter_ble_peripheral] MTU updated: \(mtu)")
+            self.maximumNotificationSize = central.maximumUpdateValueLength
+            print("[flutter_ble_peripheral] MTU updated: \(maximumNotificationSize + 3)")
 
             // Add to subscriptions and connected centrals
             txSubscriptions.insert(central.identifier)

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
@@ -74,11 +74,14 @@ class FlutterBlePeripheralManager: NSObject {
 
     // MARK: - MTU Tracking
 
-    /// The current MTU (Maximum Transmission Unit) size.
-    /// Default is 158 (minimum supported before iOS 10).
-    var mtu: Int = 158 {
+    /// The largest notification payload a subscribed central will take, which is
+    /// what Core Bluetooth reports. Default is 158 (minimum supported before iOS 10).
+    ///
+    /// Dart is given the ATT MTU, three bytes larger for the header, since that is
+    /// what Android and Windows send.
+    var maximumNotificationSize: Int = 158 {
         didSet {
-            mtuChangedHandler?.publishMtu(mtu: mtu)
+            mtuChangedHandler?.publishMtu(mtu: maximumNotificationSize + 3)
         }
     }
 

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -367,6 +367,9 @@ class FlutterBlePeripheral {
   }
 
   /// Returns Stream of MTU updates.
+  ///
+  /// This is the ATT MTU, which is three bytes larger than the largest payload
+  /// a notification can carry.
   Stream<int> get onMtuChanged {
     _mtuState ??= _mtuChangedEventChannel
         .receiveBroadcastStream()


### PR DESCRIPTION
## Description

`onMtuChanged` meant two different things depending on the platform. Android publishes the ATT MTU straight out of `onMtuChanged`, and Windows adds the three byte header back onto `MaxNotificationSize` to match it, but Apple published `central.maximumUpdateValueLength` as-is, which is the payload a notification carries and so three short. The same link reported 517 on Android and 514 on iOS.

The property is renamed to `maximumNotificationSize`, since that is what Core Bluetooth hands over, and the header is added where it is published. Nothing else read it. The default stays at 158, so a peripheral that has never had a central now starts at 161.

This changes what the stream reports on iOS and macOS, so anything sizing a payload off it there is three bytes out until it is updated.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.