### PR TITLE
fix: keep isAdvertising true while a central is connected

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
@@ -445,6 +445,11 @@ class FlutterBlePeripheralPlugin :
         if (advertisingSetCallback != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ) {
             flutterBlePeripheralManager?.stopSet(advertisingSetCallback!!)
         }
+
+        // stopAdvertising does not call back, so nothing else reports the stop and
+        // the state would sit on advertising, the way the Apple side publishes it.
+        peripheralStateChangedHandler.publish(PeripheralState.idle)
+
         safeResult(result) {
             result.success(PeripheralBluetoothState.Ready.ordinal)
         }
@@ -462,7 +467,12 @@ class FlutterBlePeripheralPlugin :
 
     private fun handleIsAdvertising(result: MethodChannel.Result) {
         safeResult(result) {
-            result.success(peripheralStateChangedHandler.state == PeripheralState.advertising)
+            // A central connecting does not end the advertisement, so both states
+            // mean the advertiser is still running.
+            val state = peripheralStateChangedHandler.state
+            result.success(
+                state == PeripheralState.advertising || state == PeripheralState.connected
+            )
         }
     }
 

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
@@ -127,7 +127,10 @@ public class FlutterBlePeripheralPlugin: NSObject, FlutterPlugin {
         case "hasPermission", "requestPermission":
             result(flutterBlePeripheralManager.permissionState.rawValue)
         case "isAdvertising":
-            result(stateChangedHandler.state == PeripheralState.advertising)
+            // Core Bluetooth answers this directly. The published state cannot,
+            // since a connected central moves it off advertising while the
+            // advertisement is still running.
+            result(flutterBlePeripheralManager.peripheralManager.isAdvertising)
         case "isSupported":
             isSupported(result)
         case "isConnected":

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -221,6 +221,10 @@ class FlutterBlePeripheral {
   }
 
   /// Returns `true` if advertising or false if not advertising
+  ///
+  /// A connected central does not end the advertisement, so this stays `true`
+  /// while one is attached, unlike [onPeripheralStateChanged], which moves to
+  /// [PeripheralState.connected].
   Future<bool> get isAdvertising async {
     return await _methodChannel.invokeMethod<bool>('isAdvertising') ?? false;
   }


### PR DESCRIPTION
## Description

Android and Apple both answered `isAdvertising` from the published `PeripheralState`, which moves to `connected` as soon as a central attaches. A connection does not end the advertisement on either platform, so both were reporting `false` while still on air. Apple has `CBPeripheralManager.isAdvertising` and can just answer with it; Android has nothing equivalent, so it counts `connected` as advertising too.

While in there: Android never published `idle` on `stop()`, since `stopAdvertising` does not call back and nothing else reported it. The state sat on `advertising` after stopping, which `isAdvertising` then answered from — so it was stuck `true` in the other direction. It publishes the stop now, the way the Apple side already does.

Windows is unaffected; it tracks the advertisement itself rather than deriving it from the state.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.