### PR TITLE
docs: sendData throws when no central is subscribed

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,10 @@ GATT database between connections and a characteristic uuid that moves breaks th
 link.
 
 `sendData` only reaches a central that subscribed to TX, which is not the same as one
-that merely connected. Watch `onSubscriptionChanged`, or check `isSubscribed`, to know
-when it can deliver. Payloads are queued per central, so back-to-back calls arrive in
-order rather than overwriting each other, and a central that reads TX gets the payload
-sent last.
+that merely connected, and throws a `PlatformException` when none has. Watch
+`onSubscriptionChanged`, or check `isSubscribed`, to know when it can deliver.
+Payloads are queued per central, so back-to-back calls arrive in order rather than
+overwriting each other, and a central that reads TX gets the payload sent last.
 
 Not supported on Windows yet.
 

--- a/example/README.md
+++ b/example/README.md
@@ -96,7 +96,8 @@ await FlutterBlePeripheral().sendData(Uint8List.fromList([1, 2, 3]));
 
 - Stopping advertising closes the GATT server and drops any queued payloads.
 - `sendData` queues per central, so back-to-back calls arrive in order rather
-  than overwriting each other.
+  than overwriting each other. It throws when no central is subscribed, rather
+  than dropping the payload.
 - A central that reads TX gets the payload sent last, so one that subscribes
   late can still pick it up.
 - Several centrals can connect at once. The example is written around a single

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -254,8 +254,11 @@ class FlutterBlePeripheral {
   /// Send data to the subscribed centrals over the GATT server.
   ///
   /// The payload is queued per central, so back-to-back calls are delivered in
-  /// order rather than overwriting each other. It is dropped when no central is
-  /// subscribed; see [isSubscribed] and [onSubscriptionChanged].
+  /// order rather than overwriting each other.
+  ///
+  /// Throws a [PlatformException] with code `SEND_FAILED` when no central is
+  /// subscribed, and `NOT_INITIALIZED` when no GATT server is running; see
+  /// [isSubscribed] and [onSubscriptionChanged] for how to know beforehand.
   ///
   /// A central that reads the TX characteristic gets the payload sent last.
   Future<void> sendData(Uint8List data) async {


### PR DESCRIPTION
## Description

The doc on `sendData` said the payload "is dropped when no central is subscribed", but every platform returns `SEND_FAILED` and the future throws. Same in the README and the example notes. Documents the two error codes it can throw while I am in there.

No behaviour change.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.