### PR TITLE
fix(windows): stop a failed radio read from taking the process down

### DIFF
--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -197,11 +197,17 @@ namespace flutter_ble_peripheral {
         // Until this has run there is no radio to report on, so a listener that
         // attached in the meantime is still sitting on unknown, and a start() is
         // still waiting on a radio that had not been found yet.
-        auto state = bluetoothRadio ? StateOf(bluetoothRadio.State()) : PeripheralState::Unsupported;
-        co_await ui_thread_;
-        if (!*alive) co_return;
-        if (!StartPendingAdvertisement()) {
-            PublishState(state);
+        auto state = CurrentState();
+        try {
+            co_await ui_thread_;
+            if (!*alive) co_return;
+            if (!StartPendingAdvertisement()) {
+                PublishState(state);
+            }
+        }
+        catch (...) {
+            // An exception leaving here would take the process with it, and there
+            // is nothing left to report to anyway.
         }
     }
 
@@ -1058,6 +1064,17 @@ namespace flutter_ble_peripheral {
         }
     }
 
+    PeripheralState FlutterBlePeripheralPlugin::CurrentState() const {
+        try {
+            return bluetoothRadio ? StateOf(bluetoothRadio.State())
+                                  : PeripheralState::Unsupported;
+        }
+        catch (...) {
+            // The radio went away between finding it and reading it.
+            return PeripheralState::Unsupported;
+        }
+    }
+
     PeripheralState FlutterBlePeripheralPlugin::StateOf(RadioState radio_state) const {
         switch (radio_state) {
             case RadioState::On:
@@ -1073,13 +1090,18 @@ namespace flutter_ble_peripheral {
     }
 
     bool FlutterBlePeripheralPlugin::StartPendingAdvertisement() {
-        if (!advertisement_pending_ || !bluetoothLEPublisher || !bluetoothRadio ||
-            bluetoothRadio.State() != RadioState::On) {
+        if (!advertisement_pending_ || !bluetoothLEPublisher || !bluetoothRadio) {
             return false;
         }
 
-        advertisement_pending_ = false;
         try {
+            // Reading the state throws once the radio has gone away, which leaves
+            // the advertisement pending rather than issuing it into nothing.
+            if (bluetoothRadio.State() != RadioState::On) {
+                return false;
+            }
+
+            advertisement_pending_ = false;
             // The service was held back with the advertisement, since nothing can
             // be served while the radio is down. It issues the advertisement
             // itself once it is up, with nobody left waiting on the answer.

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -181,6 +181,9 @@ namespace flutter_ble_peripheral {
         // The state a Bluetooth radio in this state puts the peripheral in.
         PeripheralState StateOf(RadioState radio_state) const;
 
+        // The state the radio is in now, or unsupported when it cannot be read.
+        PeripheralState CurrentState() const;
+
         // Issues an advertisement held back while the radio was down, reporting
         // whether it went out; the publisher reports the resulting state itself.
         bool StartPendingAdvertisement();


### PR DESCRIPTION
## Description

`InitializeAsync` read `bluetoothRadio.State()` outside its try, inside a `fire_and_forget`. The radio can go away between being found and being read — unplugged, or disabled in Device Manager — and the `hresult_error` that comes back then reaches the coroutine's `unhandled_exception`, which is `winrt::terminate`. The app goes down rather than reporting unsupported. `StartPendingAdvertisement` read it the same way, on the same path.

The read moves into a `CurrentState()` helper that answers unsupported when it throws, the way the central plugin's `GetCurrentState` already does, and the tail of `InitializeAsync` is wrapped so nothing else can escape either. A radio that disappears while an advertisement is held back now leaves it pending instead of issuing it into nothing.

Not something I could trigger on purpose, so this is from reading rather than from a crash.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.