### PR TITLE
fix(apple): report peripheral support from core bluetooth, not beacon monitoring

### DIFF
--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import CoreBluetooth
-import CoreLocation
 
 extension FlutterBlePeripheralManager: CBPeripheralManagerDelegate {
     

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import CoreBluetooth
-import CoreLocation
 
 /**
  The `FlutterBlePeripheralManager` class manages BLE peripheral functionality

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralPlugin.swift
@@ -5,7 +5,6 @@ import UIKit
 import FlutterMacOS
 import AppKit
 #endif
-import CoreLocation
 import CoreBluetooth
 
 /**
@@ -259,12 +258,16 @@ public class FlutterBlePeripheralPlugin: NSObject, FlutterPlugin {
 #endif
     }
 
+    /**
+     Reports whether this device supports BLE peripheral mode.
+
+     Core Bluetooth only rules peripheral mode out with `.unsupported`; every
+     other state is a condition that can change (Bluetooth off, permission not
+     granted yet) rather than missing support. `.unknown` is the state before
+     the first `peripheralManagerDidUpdateState`, so it counts as supported too.
+     */
     private func isSupported(_ result: @escaping FlutterResult) {
-        if CLLocationManager.isMonitoringAvailable(for: CLBeaconRegion.self) {
-            result(true)
-        } else {
-            result(false)
-        }
+        result(flutterBlePeripheralManager.peripheralManager.state != .unsupported)
     }
 
     /**

--- a/lib/src/flutter_ble_peripheral.dart
+++ b/lib/src/flutter_ble_peripheral.dart
@@ -229,7 +229,11 @@ class FlutterBlePeripheral {
     return await _methodChannel.invokeMethod<bool>('isAdvertising') ?? false;
   }
 
-  /// Returns `true` if advertising over BLE is supported
+  /// Returns `true` if advertising over BLE is supported by this device.
+  ///
+  /// This reports hardware capability only. It stays `true` when Bluetooth is
+  /// off or permission has not been granted yet, which
+  /// [PeripheralBluetoothState] and [hasPermission] report instead.
   Future<bool> get isSupported async =>
       await _methodChannel.invokeMethod<bool>('isSupported') ?? false;
 


### PR DESCRIPTION
## Description

`isSupported` asked Core Location whether iBeacon monitoring was available, which is always false on macOS, so the plugin reported peripheral mode as unsupported there. It now derives from `CBPeripheralManager.state`.

## Checklist

- [ ] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.