### PR TITLE
fix(windows): wait for the radio lookup before answering isSupported

### DIFF
--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -204,11 +204,24 @@ namespace flutter_ble_peripheral {
             if (!StartPendingAdvertisement()) {
                 PublishState(state);
             }
+
+            radio_looked_up_ = true;
+            auto waiting = std::move(waiting_on_radio_);
+            waiting_on_radio_.clear();
+            for (auto& work : waiting) work();
         }
         catch (...) {
             // An exception leaving here would take the process with it, and there
             // is nothing left to report to anyway.
         }
+    }
+
+    void FlutterBlePeripheralPlugin::WhenRadioReady(std::function<void()> work) {
+        if (radio_looked_up_) {
+            work();
+            return;
+        }
+        waiting_on_radio_.push_back(std::move(work));
     }
 
 
@@ -879,21 +892,27 @@ namespace flutter_ble_peripheral {
             result->Success(IsAdvertising());
         }
         else if (method_call.method_name().compare("isSupported") == 0) {
-            bool supported = bluetoothRadio != nullptr &&
-                bluetoothRadio.State() != RadioState::Disabled;
-            result->Success(supported);
+            WhenRadioReady([this, shared = std::shared_ptr(std::move(result))]() {
+                bool supported = bluetoothRadio != nullptr &&
+                    bluetoothRadio.State() != RadioState::Disabled;
+                shared->Success(supported);
+            });
+            return;
         }
         else if (method_call.method_name().compare("isBluetoothOn") == 0) {
-            bool isOn = false;
-            try {
-                if (bluetoothRadio) {
-                    isOn = (bluetoothRadio.State() == RadioState::On);
+            WhenRadioReady([this, shared = std::shared_ptr(std::move(result))]() {
+                bool isOn = false;
+                try {
+                    if (bluetoothRadio) {
+                        isOn = (bluetoothRadio.State() == RadioState::On);
+                    }
                 }
-            }
-            catch (...) {
-                isOn = false;
-            }
-            result->Success(isOn);
+                catch (...) {
+                    isOn = false;
+                }
+                shared->Success(isOn);
+            });
+            return;
         }
         else if (method_call.method_name().compare("isConnected") == 0) {
             // Windows reports subscribers rather than connections, so this is the

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -25,6 +25,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <string>
 #include <vector>
 #include <map>
@@ -188,6 +189,12 @@ namespace flutter_ble_peripheral {
         // whether it went out; the publisher reports the resulting state itself.
         bool StartPendingAdvertisement();
 
+        // Runs work that needs the radio, once InitializeAsync has looked it up.
+        // A call arriving before that would read a null radio and report the
+        // peripheral role missing when it is only late, the way start() is held
+        // back rather than dropped.
+        void WhenRadioReady(std::function<void()> work);
+
         // Starts the countdown that ends the advertisement just started, if the
         // settings asked for one.
         void ArmAdvertiseTimeout();
@@ -203,6 +210,11 @@ namespace flutter_ble_peripheral {
         // Set when start() is called before the radio is up, so that the
         // advertisement can be issued once it comes on rather than being dropped.
         bool advertisement_pending_ = false;
+
+        // Whether InitializeAsync has finished. Both this and the queue are only
+        // touched on the UI thread, so neither needs a lock.
+        bool radio_looked_up_ = false;
+        std::vector<std::function<void()>> waiting_on_radio_;
 
         // Whether the publisher has a payload to carry. False when the GATT
         // service is the only thing being advertised.


### PR DESCRIPTION
## Description

Ran the interop harness with Windows as the peripheral for the first time and it never
got off the ground: `isSupported` answered false and the harness gave up before
advertising. Windows can serve the role perfectly well — the plugin just answers before
it knows.

`isSupported` and `isBluetoothOn` read `bluetoothRadio` straight, and that is filled in by
`InitializeAsync` fired from the constructor, so anything asking in the first moments of
the process is told the radio is missing when it has only not been found yet. A `start()`
arriving in that window is already held back rather than dropped, so this makes those two
wait the same way.

With this, Windows peripheral to Android central runs 27 of 29, the two skips being
bonding. The same bug and the same fix are in flutter_ble_central, as
juliansteenbakker/flutter_ble_central#121.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
