### PR TITLE
fix: only offer a local name where the platform broadcasts one

### DIFF
--- a/example/lib/pages/link_page.dart
+++ b/example/lib/pages/link_page.dart
@@ -4,6 +4,7 @@
  * BSD-style license that can be found in the LICENSE file.
  */
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_ble_peripheral/flutter_ble_peripheral.dart';
 import 'package:flutter_ble_peripheral_example/peripheral_controller.dart';
@@ -153,7 +154,8 @@ class _AdvertiseDataPanelState extends State<_AdvertiseDataPanel> {
       footnote: locked
           ? 'Stop advertising to change what is broadcast.'
           : 'Apple broadcasts the service uuid and the local name only. '
-                'Everything else is Android and Windows.',
+                'Everything else is Android and Windows, and neither of them '
+                'puts a local name on the air.',
       children: [
         TextField(
           controller: _service,
@@ -165,11 +167,37 @@ class _AdvertiseDataPanelState extends State<_AdvertiseDataPanel> {
         ),
         TextField(
           controller: _name,
-          enabled: !locked,
+          // Greyed off Apple rather than hidden, so the page says which
+          // platforms carry a name of their own and which do not.
+          enabled: !locked && PeripheralController.carriesLocalName,
           style: context.tokens.readout,
-          decoration: const InputDecoration(labelText: 'LOCAL NAME'),
+          decoration: InputDecoration(
+            labelText: 'LOCAL NAME · APPLE',
+            helperText: PeripheralController.carriesLocalName
+                ? null
+                : 'Not broadcast on ${defaultTargetPlatform.name}',
+          ),
           onChanged: (value) =>
               _controller.update(() => _controller.localName = value),
+        ),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          value: _controller.includeDeviceName,
+          onChanged: locked
+              ? null
+              : (value) => _controller.update(
+                  () => _controller.includeDeviceName = value,
+                ),
+          title: Text(
+            'Include device name · Android',
+            style: context.texts.labelLarge,
+          ),
+          subtitle: Text(
+            'Broadcasts the system Bluetooth name, the only name Android can '
+            'advertise. It goes in the scan response, since the advertisement '
+            'has no room left for it.',
+            style: context.texts.bodySmall,
+          ),
         ),
         TextField(
           controller: _manufacturerId,

--- a/example/lib/peripheral_controller.dart
+++ b/example/lib/peripheral_controller.dart
@@ -53,8 +53,32 @@ final class PeripheralController extends ChangeNotifier implements RadioAccess {
   /// The uuid of the advertised service, which is also the GATT service.
   String serviceUuid = exampleServiceUuid;
 
-  /// The name broadcast alongside it.
+  /// The name broadcast alongside it, on the platforms that carry one.
+  ///
+  /// Apple is the only one: Android has no way to put a name of its own in an
+  /// advertisement, and a legacy Windows advertisement refuses to start with
+  /// one set. See [carriesLocalName] and [includeDeviceName].
   String localName = exampleLocalName;
+
+  /// Whether Android broadcasts the system Bluetooth name.
+  ///
+  /// The only name Android can advertise. `AdvertiseData.Builder` takes no
+  /// name of its own, and the stack fills this one in from the adapter, so it
+  /// is whatever the device is called in Settings rather than [localName].
+  ///
+  /// It goes in the scan response rather than the advertisement, which has no
+  /// room for it: flags and a 128-bit service uuid come to 21 of the 31 bytes
+  /// a legacy advertisement holds, the manufacturer data below takes the other
+  /// 10, and a name Android refuses to truncate needs its length plus two.
+  /// Asking for it in the advertisement fails the whole call with
+  /// `ADVERTISE_FAILED_DATA_TOO_LARGE`. The scan response is a second 31 bytes,
+  /// which is what it is for.
+  bool includeDeviceName = false;
+
+  /// Whether this platform puts [localName] on the air.
+  static bool get carriesLocalName =>
+      defaultTargetPlatform == TargetPlatform.iOS ||
+      defaultTargetPlatform == TargetPlatform.macOS;
 
   /// The manufacturer identifier, or null to advertise none.
   int? manufacturerId = 1234;
@@ -192,6 +216,11 @@ final class PeripheralController extends ChangeNotifier implements RadioAccess {
             timeout: timeout,
             connectable: connectable,
           ),
+          // The name goes here rather than in the advertisement, which is
+          // already full. See [includeDeviceName].
+          advertiseResponseData: includeDeviceName
+              ? const AndroidAdvertiseData(includeDeviceName: true)
+              : null,
         ),
         darwinSettings: DarwinAdvertiseSettings(
           overflowServiceUuids: useOverflowArea ? [serviceUuid] : null,
@@ -205,7 +234,13 @@ final class PeripheralController extends ChangeNotifier implements RadioAccess {
         _say('Cannot advertise: ${state.access.label}', isError: true);
         return;
       }
-      _say('Advertising $localName');
+      // Only say the name where it is actually on the air, rather than
+      // reporting one the platform dropped.
+      _say(
+        carriesLocalName && localName.isNotEmpty
+            ? 'Advertising $localName'
+            : 'Advertising $serviceUuid',
+      );
     } on PlatformException catch (error) {
       _say('Advertising failed: ${error.message}', isError: true);
     }


### PR DESCRIPTION
## Description

The example's LOCAL NAME field did nothing on Android or Windows, and the app then
cheerfully reported "Advertising <name>" over a name that never left the device. Scanning
from a Mac showed the peripheral as unnamed, which is what sent me looking.

Android has no way to put a name of its own in an advertisement. `AdvertiseData.Builder`
has five setters and none of them takes a name; `setIncludeDeviceName(true)` is the only
name-related one and the stack fills that field in from the adapter, so the only lever is
`BluetoothAdapter.setName()`, which renames the whole device. A legacy Windows
advertisement refuses to start at all with a local name set. So `localName` reaching only
Apple is correct and stays as it is — the README already said so, the example just did not
act like it.

The field is now labelled for Apple and greyed elsewhere with the reason, the way the
Setup page already labels what a given platform does not read, and the notice reports the
service uuid where the name is dropped.

Android's system name is offered instead, as a switch, and it goes in the scan response
rather than the advertisement. It does not fit there: flags and a 128-bit service uuid come
to 21 of the 31 bytes a legacy advertisement holds and the manufacturer data takes the
other 10, so asking for the name fails the whole call with
`ADVERTISE_FAILED_DATA_TOO_LARGE`. Dropping the manufacturer data does not rescue it
either — the ten bytes that frees hold eight characters of a name Android will not
truncate, and this tablet is called "Tab Active5 van Julian". The scan response is a second
31 bytes, which is what it is for, and it is what the phones around me already do.

Checked on an Android tablet, four ways: defaults with no name starts; the name in the
advertisement fails; the name in the scan response starts; the name in the advertisement
without manufacturer data still fails. Then driven through the real controller with the
switch on and scanned from Windows, which reads the name on every result once the first
scan response comes back.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
