### PR TITLE
fix(example): defer link meter reports made while the tree is locked

### DIFF
--- a/example/lib/shell/link_meter.dart
+++ b/example/lib/shell/link_meter.dart
@@ -35,6 +35,8 @@ final class LinkTelemetry extends ChangeNotifier {
   String _caption = 'idle';
   int _inbound = 0;
   int _outbound = 0;
+  bool _pending = false;
+  bool _disposed = false;
 
   /// How good the link is.
   SignalGrade get grade => _grade;
@@ -65,7 +67,7 @@ final class LinkTelemetry extends ChangeNotifier {
     _grade = grade;
     _caption = caption;
     _level = level;
-    notifyListeners();
+    _notify();
   }
 
   /// Counts [count] packets that went [direction].
@@ -76,11 +78,37 @@ final class LinkTelemetry extends ChangeNotifier {
       case PacketDirection.outbound:
         _outbound += count;
     }
-    notifyListeners();
+    _notify();
   }
 
   /// Drops the trace back to idle, keeping the counts.
   void clear() => report(grade: SignalGrade.none, caption: 'idle');
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
+  /// Notifies, waiting for the end of the frame if the tree is locked.
+  ///
+  /// A page reports from its own `dispose`, which runs while the framework is
+  /// finalizing the tree and nothing may be marked dirty. The meter and the
+  /// readout beside it listen from above that page, so the report has to wait
+  /// for the frame to end.
+  void _notify() {
+    if (SchedulerBinding.instance.schedulerPhase !=
+        SchedulerPhase.persistentCallbacks) {
+      notifyListeners();
+      return;
+    }
+    if (_pending) return;
+    _pending = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _pending = false;
+      if (!_disposed) notifyListeners();
+    });
+  }
 }
 
 /// The one bold element in the shell: a live plot of the radio link.


### PR DESCRIPTION
## Description

`LinkTelemetry` notifies synchronously, so a page that clears the link meter from its
`dispose` marks the readout above it dirty while `finalizeTree` is still unmounting the
subtree: `setState() or markNeedsBuild() called when widget tree was locked`. Hit it on
the central side leaving the Pong page, and the shell here is the same code.

A report that lands during the persistent frame callbacks now waits for the end of the
frame, coalesced so a burst only notifies once, and the deferred notify is dropped if the
telemetry has been disposed by the time it runs — the controller owns it and tears it
down in the same unmount pass when the app goes away.

Same commit as juliansteenbakker/flutter_ble_central#125; `link_meter.dart` is one of the
shared files.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
