### PR TITLE
feat: keep the old state name as a deprecated alias

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,84 @@
+# Migration guide
+
+## 2.x to 3.0.0
+
+Everything to do with advertising was split into a shared core plus one settings
+object per platform, so a call site no longer mixes fields that only one platform
+honours with fields every platform honours.
+
+| Removed | Replaced with |
+| --- | --- |
+| `AdvertiseData` | `AdvertiseDataCore` for the cross-platform fields, `AndroidAdvertiseData` for the Android-only ones |
+| `AdvertiseData.includePowerLevel` | `includeTxPowerLevel`, which every platform that supports it now reads |
+| `start(advertiseSettings:)`, `start(advertiseSetParameters:)`, `start(advertiseResponseData:)`, `start(advertisePeriodicData:)`, `start(periodicAdvertiseSettings:)` | `start(androidSettings: AndroidAdvertiseSettings(...))`, which holds all five; `advertisePeriodicData` is `periodicAdvertiseData` there |
+| `AdvertiseSettings.advertiseSet` | Passing `AndroidAdvertiseSettings.advertiseSetParameters` selects the extended advertising API. It is now mutually exclusive with `advertiseSettings`, where 2.x took both and let `advertiseSet` pick |
+| `PermissionState` | `PeripheralBluetoothState`, which covers the same permission cases plus the adapter states |
+| `BluetoothPeripheralState` | `PeripheralBluetoothState`, so this package and `flutter_ble_central` no longer declare colliding type names. The old name stays as a deprecated alias in 3.0 and is removed in the next breaking release |
+
+Changed rather than removed:
+
+- `AdvertiseSetParameters.anonymous` is a `bool?`, not an `int?`.
+- `AdvertiseSettings` defaults: `timeout` is `0`, meaning no timeout, instead of
+  `400`, and `txPowerLevel` is `advertiseTxPowerHigh` instead of
+  `advertiseTxPowerLow`.
+- `PeripheralState` carries `locationServicesDisabled` again, which shifts the
+  index of every entry after it. Switch on the values, not on `.values[i]`.
+- The files under `lib/src` moved into `core/` and `platform/<platform>/`. Only a
+  direct `package:flutter_ble_peripheral/src/...` import breaks; everything is
+  still exported from `package:flutter_ble_peripheral/flutter_ble_peripheral.dart`.
+
+Before:
+
+```dart
+await FlutterBlePeripheral().start(
+  advertiseData: AdvertiseData(
+    serviceUuid: 'bf27730d-860a-4e09-889c-2d8b6a9e0fe7',
+    localName: 'My peripheral',
+    includePowerLevel: true,
+    includeDeviceName: true,
+  ),
+  advertiseSettings: AdvertiseSettings(advertiseSet: false, timeout: 400),
+  advertiseResponseData: AdvertiseData(includeDeviceName: true),
+);
+```
+
+After:
+
+```dart
+await FlutterBlePeripheral().start(
+  advertiseData: const AndroidAdvertiseData(
+    serviceUuid: 'bf27730d-860a-4e09-889c-2d8b6a9e0fe7',
+    localName: 'My peripheral',
+    includeTxPowerLevel: true,
+    includeDeviceName: true,
+  ),
+  androidSettings: const AndroidAdvertiseSettings(
+    advertiseSettings: AdvertiseSettings(timeout: 400),
+    advertiseResponseData: AndroidAdvertiseData(includeDeviceName: true),
+  ),
+);
+```
+
+For the extended path, pass `advertiseSetParameters` instead of
+`advertiseSettings`, which is where periodic advertising lives:
+
+```dart
+androidSettings: const AndroidAdvertiseSettings(
+  advertiseSetParameters: AdvertiseSetParameters(),
+  periodicAdvertiseData: AndroidAdvertiseData(
+    serviceUuid: 'bf27730d-860a-4e09-889c-2d8b6a9e0fe7',
+  ),
+  periodicAdvertiseSettings: PeriodicAdvertiseSettings(),
+),
+```
+
+Apart from what is listed above, `AdvertiseSettings`, `AdvertiseSetParameters` and
+`PeriodicAdvertiseSettings` keep their names and fields; they moved inside
+`AndroidAdvertiseSettings` rather than sitting on `start()`. `DarwinAdvertiseSettings` and `WindowsAdvertiseSettings` are
+the equivalents for the other platforms. Drop `AndroidAdvertiseData` for
+`AdvertiseDataCore` if the call site does not set any of the Android-only fields.
+
+`PermissionState` has no alias on purpose. Its entries are declared in a different
+order than `PeripheralBluetoothState`'s, and these values cross the platform
+channel by ordinal, so mapping the old values across by index gives the wrong
+state rather than a compile error.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ advertisement as public.
 flutter pub add flutter_ble_peripheral
 ```
 
+Upgrading from 2.x? See [MIGRATION.md](MIGRATION.md).
+
 ## Platform setup
 
 ### Android

--- a/lib/src/core/enums/peripheral_bluetooth_state.dart
+++ b/lib/src/core/enums/peripheral_bluetooth_state.dart
@@ -56,3 +56,10 @@ enum PeripheralBluetoothState {
   @JsonValue(8)
   ready,
 }
+
+/// Former name of [PeripheralBluetoothState].
+@Deprecated(
+  'Renamed to PeripheralBluetoothState so it no longer collides with the '
+  'central package. Will be removed in the next breaking release.',
+)
+typedef BluetoothPeripheralState = PeripheralBluetoothState;

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -207,6 +207,13 @@ void main() {
       );
       expect(PeripheralBluetoothState.values, hasLength(9));
     });
+
+    test('the BluetoothPeripheralState alias resolves to it', () {
+      // Exercising the deprecated alias is the point of this test.
+      // ignore: deprecated_member_use_from_same_package
+      const state = BluetoothPeripheralState.ready;
+      expect(state, PeripheralBluetoothState.ready);
+    });
   });
 
   group('PeripheralState', () {


### PR DESCRIPTION
## Description

Same treatment as flutter_ble_central#128. `BluetoothPeripheralState` comes back as a deprecated typedef so the rename in #301 gives a deprecation window instead of breaking every call site at once. It goes for good in the next breaking release.

`PermissionState` deliberately gets no alias. Its entries were declared in a different order than `PeripheralBluetoothState`'s and these values cross the channel by ordinal, so an alias would silently hand back the wrong state instead of failing to compile.

I also moved the "Breaking changes in 3.0" section out of the readme into a `MIGRATION.md`, linked from the readme, matching the central package. Same content, and it keeps the readme from collecting a section per major.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [x] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.