### PR TITLE
ci: group and cool down dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,35 @@
 version: 2
+
+# Applies to every ecosystem below.
+#
+# A "<type>(scope): ..." prefix is required, otherwise semantic-pr.yml rejects
+# Dependabot's default "Bump x from y to z" titles.
+#
+# Ecosystems that ship to plugin consumers (the plugin's own Android/pub
+# dependencies) use "deps", which release-please renders under a "Dependencies"
+# changelog heading. Dev-only ecosystems (CI actions, the example app) use
+# "chore" so they stay out of the changelog. Reviewers are not listed:
+# CODEOWNERS already requests review on everything, and the key is deprecated.
+#
+# The cooldown lets a release settle before it is proposed, so that a version
+# superseded within days never costs a PR. Security updates ignore it.
+#
+# There is no swift ecosystem entry: darwin/flutter_ble_peripheral/Package.swift
+# only depends on the local FlutterFramework path package, so there is nothing
+# for Dependabot to bump. The Windows plugin has no external dependencies
+# either, it links against the Windows SDK/WinRT directly.
 updates:
-  # A "<type>(scope): ..." prefix is required on every ecosystem here, otherwise
-  # semantic-pr.yml rejects Dependabot's default "Bump x from y to z" titles.
-  #
-  # Ecosystems that ship to plugin consumers (the plugin's own Android/pub
-  # dependencies) use "deps", which release-please renders under a
-  # "Dependencies" changelog heading. Dev-only ecosystems (CI actions, the
-  # example app) use "chore" so they stay out of the changelog.
-  #
-  # There is no swift ecosystem entry: darwin/flutter_ble_peripheral/Package.swift
-  # only depends on the local FlutterFramework path package, so there is nothing
-  # for Dependabot to bump. The Windows plugin has no external dependencies
-  # either -- it links against the Windows SDK/WinRT directly.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
       include: scope
@@ -26,38 +38,51 @@ updates:
     directory: /android
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     commit-message:
       prefix: deps
-      include: scope
 
   - package-ecosystem: gradle
     directory: /example/android
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      example-android:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
       include: scope
 
+  # prefix-development keeps a bump of a dev_dependency, which no consumer of
+  # the package resolves, out of the "Dependencies" changelog section.
   - package-ecosystem: pub
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     commit-message:
       prefix: deps
-      include: scope
+      prefix-development: chore
 
   - package-ecosystem: pub
     directory: /example
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      example-dart:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
       include: scope

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ migrate_working_dir/
 .flutter-plugins-dependencies
 /build/
 /coverage/
+
+# Swift Package Manager and Xcode. Package.resolved is deliberately not
+# committed: this is a library, so the resolved versions come from the app that
+# consumes it, and pinning the example app would work against the CI jobs that
+# prove the plugin still builds against current versions.
+Package.resolved
+**/ios/**/xcshareddata/swiftpm/
+**/macos/**/xcshareddata/swiftpm/


### PR DESCRIPTION
## Description

Same dependabot cleanup as nordic_dfu#306. Coverage was already complete, this is about how the updates arrive.

- Dev-only ecosystems (actions, example app) are grouped into one PR each, and everything gets a 7 day cooldown, so a version that is superseded within the week no longer costs two PRs.
- The `deps` entries lose `include: scope`, which was producing `deps(deps): ...` titles.
- The root pubspec gets `prefix-development: chore`, so a `build_runner`, `json_serializable` or `very_good_analysis` bump stays out of the Dependencies section of the changelog while `json_annotation` still lands there.
- `reviewers` is gone everywhere, CODEOWNERS already covers it and the key is deprecated.

Also ignoring `Package.resolved` and the generated `xcshareddata/swiftpm/` directories, which a local darwin build leaves behind. `.build/` and `.swiftpm/` were already ignored.

No podspec pin check here, unlike nordic_dfu: this plugin's podspec has no external dependency to keep in sync.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
