### PR TITLE
chore: stop the deprecated state alias failing analysis in 3.0

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,3 +11,10 @@ analyzer:
     - linux/**
     # json_serializable output; not ours to lint or document.
     - "**/*.g.dart"
+
+linter:
+  rules:
+    # The rename alias in PeripheralBluetoothState is deliberately deprecated
+    # for one breaking release, so 2.x call sites get a warning before the old
+    # name disappears rather than a compile error on upgrade.
+    remove_deprecations_in_breaking_versions: false


### PR DESCRIPTION
## Description

`remove_deprecations_in_breaking_versions` fires on the `BluetoothPeripheralState`
alias as soon as the version is 3.0.0, so analysis fails on the release-please PR
even though develop is clean. Keeping the alias for one breaking release is the
point, so I turned the rule off. A local `// ignore:` does not work here: it trips
`unnecessary_ignore` on develop, where the version is still 2.1.1.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
