### PR TITLE
ci: drop semver-major-days from the dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       github-actions:
         patterns:
@@ -40,7 +39,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     commit-message:
       prefix: deps
 
@@ -50,7 +48,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       example-android:
         patterns:
@@ -67,7 +64,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     commit-message:
       prefix: deps
       prefix-development: chore
@@ -78,7 +74,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       example-dart:
         patterns:


### PR DESCRIPTION
## Description

The cooldown I added in the previous PR broke the config. Dependabot rejects `semver-major-days` for the `github-actions` ecosystem, and a parse error takes the whole file down, so no updates are running on develop right now.

The option is only accepted for ecosystems whose versions Dependabot classifies as semver. Rather than keep it on the entries where it might be allowed and have the file differ per ecosystem for non-obvious reasons, every entry now uses `default-days: 7` alone. The churn suppression that was the point of the cooldown is unaffected, majors just no longer get a longer window.

Same fix as nordic_dfu#308.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
