### PR TITLE
feat(apple): restore the advertisement after a background relaunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ On macOS, also tick the Bluetooth entitlement in **both**
 <true/>
 ```
 
+To keep advertising once the app is no longer in front, add the background mode to
+`ios/Runner/Info.plist`:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>bluetooth-peripheral</string>
+</array>
+```
+
+Without it iOS stops the advertisement when the app leaves the foreground. What it
+does to the advertisement that stays on air, and what the plugin does with the key
+beyond that, is under [Background advertising](#background-advertising). macOS has no
+background modes, and keeps advertising for as long as the app runs.
+
 ### Windows
 
 No manifest changes are needed. Windows requires the location permission for BLE, which
@@ -228,6 +243,34 @@ the service carries itself, this is also the one case where Windows accepts an
 advertisement without manufacturer data or service data. The advertise timeout ends
 what the service has on air along with the publisher, leaving it serving whoever is
 already connected, the same as an Android advertise timeout does.
+
+### Background advertising
+
+On Android the advertisement belongs to the process, so it keeps going while the app
+sits in the background and ends when the system kills the process. Advertising from a
+service rather than from an activity is not supported yet: `start()` needs an activity
+to check permissions against, and answers with a `No activity` error without one.
+
+On iOS the advertisement ends with the foreground unless the app declares the
+`bluetooth-peripheral` background mode. With it, Core Bluetooth keeps advertising, but
+not the advertisement that was passed in:
+
+- The local name is dropped.
+- The service uuids move into the overflow area, where only an iOS central that scans
+  for those exact uuids can see them. A scan with no uuid filter, and every non-Apple
+  scanner, sees nothing at all. This is the usual reason background advertising looks
+  broken: it is on air, but nothing that is looking for it broadly will report it.
+- Advertising is slower and shares the radio with whatever else the system is doing.
+
+Declaring the background mode also lets the plugin register a restore identifier with
+Core Bluetooth, which is what allows iOS to relaunch the app into the background and
+hand back the advertisement and the GATT service, including the centrals that were
+subscribed to TX. The state, mtu and subscription streams replay their last value to a
+new listener, so an app that comes back this way sees `advertising` or `connected` on
+`onPeripheralStateChanged` and can carry on with `sendData` without calling `start()`
+again. Calling it again is safe: the advertisement is replaced rather than rejected,
+and a service that already matches is left in place, so a central stays connected
+across it.
 
 ### Streams
 

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Delegates/PeripheralManagerDelegate.swift
@@ -9,12 +9,34 @@ import Foundation
 import CoreBluetooth
 
 extension FlutterBlePeripheralManager: CBPeripheralManagerDelegate {
-    
+
+    /**
+     Core Bluetooth relaunched the app into the background and is handing back the
+     advertisement and services it kept running in the meantime.
+
+     This arrives before `peripheralManagerDidUpdateState`, and long before Dart has
+     attached to the event channels, which the handlers cover by replaying their last
+     value to a new listener.
+     */
+    func peripheralManager(_ peripheral: CBPeripheralManager, willRestoreState dict: [String: Any]) {
+        print("[flutter_ble_peripheral] willRestoreState:", dict)
+        restoreState(dict)
+    }
+
     func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
         var state: PeripheralState
         switch peripheral.state {
         case .poweredOn:
-            state = .idle
+            // A relaunch into the background comes back with the advertisement
+            // already on air, and possibly with a central still subscribed, so idle
+            // would be wrong here.
+            if txSubscribed {
+                state = .connected
+            } else if peripheral.isAdvertising {
+                state = .advertising
+            } else {
+                state = .idle
+            }
         case .poweredOff:
             state = .poweredOff
         case .resetting:

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/FlutterBlePeripheralManager.swift
@@ -44,6 +44,18 @@ class FlutterBlePeripheralManager: NSObject {
     /// The CoreBluetooth peripheral manager instance responsible for advertising and GATT management.
     var peripheralManager: CBPeripheralManager!
 
+    /// The identifier Core Bluetooth hands the advertisement and the served
+    /// services back under, after it relaunched the app into the background.
+    static let restoreIdentifier = "dev.steenbakker.flutter_ble_peripheral.peripheral_manager"
+
+    /// Whether the app declares the `bluetooth-peripheral` background mode, which
+    /// is what keeps the advertisement on air once the app is no longer in front,
+    /// and what lets Core Bluetooth relaunch the app to hand its state back.
+    static var declaresPeripheralBackgroundMode: Bool {
+        let modes = Bundle.main.object(forInfoDictionaryKey: "UIBackgroundModes") as? [String]
+        return modes?.contains("bluetooth-peripheral") ?? false
+    }
+
     // MARK: - GATT Attributes
 
     /// The currently active GATT service.
@@ -135,10 +147,22 @@ class FlutterBlePeripheralManager: NSObject {
         self.subscriptionChangedHandler = subscriptionChangedHandler
         super.init()
 
+        var options: [String: Any] = [CBPeripheralManagerOptionShowPowerAlertKey: true]
+#if os(iOS)
+        // Only an app that advertises in the background is ever relaunched to be
+        // handed its state back, so the identifier is set exactly when it asked for
+        // that. Handing one to an app without the background mode would make Core
+        // Bluetooth keep state it can never restore.
+        if FlutterBlePeripheralManager.declaresPeripheralBackgroundMode {
+            options[CBPeripheralManagerOptionRestoreIdentifierKey] =
+                FlutterBlePeripheralManager.restoreIdentifier
+        }
+#endif
+
         self.peripheralManager = CBPeripheralManager(
             delegate: self,
             queue: nil,
-            options: [CBPeripheralManagerOptionShowPowerAlertKey: true]
+            options: options
         )
     }
 
@@ -170,6 +194,14 @@ class FlutterBlePeripheralManager: NSObject {
 
         pendingAdvertisement = nil
         pendingGattService = nil
+
+        // Core Bluetooth answers a second startAdvertising with "advertising is
+        // already started" and keeps what it has, rather than replacing it, so it is
+        // stopped first. An app that comes back from a background relaunch is in
+        // exactly that state before it starts again.
+        if peripheralManager.isAdvertising {
+            peripheralManager.stopAdvertising()
+        }
         peripheralManager.startAdvertising(advertisementData)
 
         if let gattService = gattService {
@@ -188,6 +220,20 @@ class FlutterBlePeripheralManager: NSObject {
         let serviceUuid = request.serviceUuid
         let txUuid = request.txCharacteristicUuid
         let rxUuid = request.rxCharacteristicUuid
+
+        // A restored service is already being served, and adding the same layout a
+        // second time fails, so it is left alone. A different layout replaces it.
+        if let existing = currentService {
+            let sameLayout =
+                FlutterBlePeripheralManager.parseServiceUuid(serviceUuid) == existing.uuid
+                && FlutterBlePeripheralManager.parseServiceUuid(txUuid) == txCharacteristic?.uuid
+                && FlutterBlePeripheralManager.parseServiceUuid(rxUuid) == rxCharacteristic?.uuid
+            if sameLayout {
+                print("[flutter_ble_peripheral] GATT service \(serviceUuid) is already served")
+                return
+            }
+            peripheralManager.remove(existing)
+        }
 
         // TX characteristic: notify central devices of updates
         let mutableTxCharacteristic = CBMutableCharacteristic(
@@ -444,6 +490,52 @@ class FlutterBlePeripheralManager: NSObject {
             throw FlutterBlePeripheralError.invalidServiceUuid(value)
         }
         return uuid
+    }
+
+    // MARK: - Background Restoration
+
+    /**
+     Takes back the advertisement and the service Core Bluetooth kept running while
+     the app was not there, after it relaunched the app into the background.
+
+     The advertisement is already on air by the time this is called, so it is not
+     started again; what is missing is everything this class tracks about it, which
+     the restored service and its subscribed centrals give back.
+     */
+    func restoreState(_ state: [String: Any]) {
+        let services = state[CBPeripheralManagerRestoredStateServicesKey] as? [CBMutableService] ?? []
+
+        for service in services {
+            let characteristics = service.characteristics?
+                .compactMap { $0 as? CBMutableCharacteristic } ?? []
+
+            // The uuids are chosen by Dart and are not known here until it calls
+            // start again, but the properties are: TX is the notifying half of the
+            // pair and RX the written one.
+            let tx = characteristics.first { $0.properties.contains(.notify) }
+            let rx = characteristics.first {
+                $0.properties.contains(.write) || $0.properties.contains(.writeWithoutResponse)
+            }
+            guard tx != nil || rx != nil else { continue }
+
+            currentService = service
+            txCharacteristic = tx
+            rxCharacteristic = rx
+            break
+        }
+
+        // The centrals that were subscribed come back too, and that is what decides
+        // whether sendData can deliver.
+        let subscribed = txCharacteristic?.subscribedCentrals ?? []
+        txSubscriptions = Set(subscribed.map { $0.identifier })
+        connectedCentrals.formUnion(txSubscriptions)
+        if let central = subscribed.first {
+            maximumNotificationSize = central.maximumUpdateValueLength
+        }
+        txSubscribed = !txSubscriptions.isEmpty
+
+        print("[flutter_ble_peripheral] Restored \(services.count) service(s), "
+              + "\(txSubscriptions.count) subscribed central(s)")
     }
 
     /// Issues the advertisement that was queued while the radio was still coming up.

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Handlers/MtuChangedHandler.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Handlers/MtuChangedHandler.swift
@@ -18,6 +18,9 @@ public class MtuChangedHandler: NSObject, FlutterStreamHandler {
     private var eventSink: FlutterEventSink?
     private var registrar: FlutterPluginRegistrar
 
+    /// The last mtu published, replayed to a new listener.
+    private var mtu: Int?
+
     init(registrar: FlutterPluginRegistrar) {
         self.registrar = registrar
         super.init()
@@ -37,6 +40,7 @@ public class MtuChangedHandler: NSObject, FlutterStreamHandler {
     }
 
     func publishMtu(mtu: Int) {
+        self.mtu = mtu
         DispatchQueue.main.async {
             if let eventSink = self.eventSink {
                 eventSink(mtu)
@@ -47,6 +51,12 @@ public class MtuChangedHandler: NSObject, FlutterStreamHandler {
     public func onListen(withArguments arguments: Any?,
                          eventSink: @escaping FlutterEventSink) -> FlutterError? {
         self.eventSink = eventSink
+        // The mtu is negotiated once, when the central connects, which after a
+        // background relaunch is before Dart attaches, so a new listener is given
+        // the last value rather than waiting for a connection it already has.
+        if let mtu = mtu {
+            eventSink(mtu)
+        }
         return nil
     }
 

--- a/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Handlers/SubscriptionChangedHandler.swift
+++ b/darwin/flutter_ble_peripheral/Sources/flutter_ble_peripheral/Handlers/SubscriptionChangedHandler.swift
@@ -58,6 +58,12 @@ public class SubscriptionChangedHandler: NSObject, FlutterStreamHandler {
     public func onListen(withArguments arguments: Any?,
                          eventSink: @escaping FlutterEventSink) -> FlutterError? {
         self.eventSink = eventSink
+        // A new listener is given the current value, since the subscription it
+        // describes may predate it: after a background relaunch the central is
+        // already subscribed before Dart attaches.
+        if let subscribed = subscribed {
+            eventSink(subscribed)
+        }
         return nil
     }
 

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -26,6 +26,10 @@
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Bluetooth is required in order to advertise via BLE</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-peripheral</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Description

Background advertising on iOS has never worked for anyone who asked about it (#97), and
most of that turns out to be a rule we document nowhere. With `bluetooth-peripheral` in
`UIBackgroundModes` the advertisement does stay on air, but Core Bluetooth drops the local
name and moves the service uuids into the overflow area, where only an iOS central scanning
for those exact uuids can see them. nRF Connect, or any scan without a uuid filter, shows
nothing at all — so it looks dead while it is running fine. That is in the README now,
together with the plist key and the Android side of the same question, and the example
declares the background mode.

The part that was genuinely missing is state restoration. The peripheral manager takes a
restore identifier now, but only when the app declares that background mode: an app without
it is never relaunched, and handing one over anyway would leave Core Bluetooth holding state
it can never give back. `willRestoreState` picks the served service back up, taking TX by
its notify property and RX by write — the uuids are Dart's choice and are not known that
early — and reads the subscribed centrals and the mtu off the restored characteristic, so
`sendData` can deliver before the app calls `start()` again.

Three things had to change for any of that to be visible from Dart.
`peripheralManagerDidUpdateState` published `idle` on `poweredOn`, which would have
flattened a restored advertisement, so it reports what is actually going on instead —
right outside restoration too. And the subscription and mtu handlers did not replay their
last value to a new listener the way the state handler already does; after a relaunch both
predate Dart attaching, so the app would never have heard about a link it already had.

While in there, `start()` twice in a row: Core Bluetooth answers the second
`startAdvertising` with "advertising is already started" and keeps the old advertisement,
which is exactly the state an app comes back in after a relaunch, so it stops first now. A
service whose layout already matches is left alone rather than added a second time, so a
connected central survives the call. Same complaint as #205.

Built the example for the simulator and for macOS. The restoration path itself I have not
had iOS actually relaunch the app on yet — that needs a device and some patience.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.
