### PR TITLE
fix(android): accept short uuids for the gatt service and characteristics

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralManager.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralManager.kt
@@ -261,7 +261,7 @@ class FlutterBlePeripheralManager(
                 // A read gets the last value sendData pushed, so a central that
                 // subscribes late can still pick it up.
                 gattServerCallback!!.readCharacteristicValue = { uuid ->
-                    if (uuid.equals(txUuid, ignoreCase = true)) lastSentValue else null
+                    if (uuid == txUuid) lastSentValue else null
                 }
                 gattServerCallback!!.onNotificationSent = { device -> onNotificationSent(device) }
                 gattServerCallback!!.onSubscriptionChanged = { subscribed ->
@@ -277,7 +277,7 @@ class FlutterBlePeripheralManager(
 
             // Create TX characteristic (for sending data to central)
             txCharacteristic = BluetoothGattCharacteristic(
-                UUID.fromString(txUuid),
+                txUuid,
                 BluetoothGattCharacteristic.PROPERTY_READ or
                 BluetoothGattCharacteristic.PROPERTY_NOTIFY or
                 BluetoothGattCharacteristic.PROPERTY_INDICATE,
@@ -293,7 +293,7 @@ class FlutterBlePeripheralManager(
 
             // Create RX characteristic (for receiving data from central)
             rxCharacteristic = BluetoothGattCharacteristic(
-                UUID.fromString(rxUuid),
+                rxUuid,
                 BluetoothGattCharacteristic.PROPERTY_WRITE or
                 BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
                 BluetoothGattCharacteristic.PERMISSION_WRITE
@@ -301,7 +301,7 @@ class FlutterBlePeripheralManager(
 
             // Create service and add characteristics
             val service = BluetoothGattService(
-                UUID.fromString(serviceUuid),
+                serviceUuid,
                 BluetoothGattService.SERVICE_TYPE_PRIMARY
             )
             service.addCharacteristic(txCharacteristic)

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
@@ -290,13 +290,17 @@ class FlutterBlePeripheralPlugin :
      * from the service uuid.
      */
     private fun readGattService(arguments: Map<*, *>): GattServiceRequest? {
-        val serviceUuid = arguments["gattServiceUuid"] as String? ?: return null
+        val serviceUuid = arguments["gattServiceUuid"] as? String ?: return null
         return GattServiceRequest(
-                serviceUuid = serviceUuid,
-                txCharacteristicUuid = arguments["gattTxCharacteristicUuid"] as String
-                        ?: throw IllegalArgumentException("gattServiceUuid needs a gattTxCharacteristicUuid"),
-                rxCharacteristicUuid = arguments["gattRxCharacteristicUuid"] as String
-                        ?: throw IllegalArgumentException("gattServiceUuid needs a gattRxCharacteristicUuid"),
+                serviceUuid = parseServiceUuid(serviceUuid),
+                txCharacteristicUuid = parseServiceUuid(
+                        arguments["gattTxCharacteristicUuid"] as? String
+                                ?: throw IllegalArgumentException("gattServiceUuid needs a gattTxCharacteristicUuid")
+                ),
+                rxCharacteristicUuid = parseServiceUuid(
+                        arguments["gattRxCharacteristicUuid"] as? String
+                                ?: throw IllegalArgumentException("gattServiceUuid needs a gattRxCharacteristicUuid")
+                ),
         )
     }
 

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/GattServerCallback.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/callbacks/GattServerCallback.kt
@@ -20,6 +20,7 @@ import dev.steenbakker.flutter_ble_peripheral.handlers.PeripheralStateChangedHan
 import dev.steenbakker.flutter_ble_peripheral.models.PeripheralState
 import io.flutter.Log
 import java.io.ByteArrayOutputStream
+import java.util.UUID
 
 /**
  * Bridges the GATT server between Android and Flutter.
@@ -34,13 +35,13 @@ class GattServerCallback(
     private val peripheralStateChangedHandler: PeripheralStateChangedHandler,
     private val dataReceivedHandler: DataReceivedHandler?,
     private val mtuChangedHandler: MtuChangedHandler?,
-    private val txCharacteristicUuid: String,
-    private val rxCharacteristicUuid: String
+    private val txCharacteristicUuid: UUID,
+    private val rxCharacteristicUuid: UUID
 ) : BluetoothGattServerCallback() {
 
     private companion object {
         /** Client Characteristic Configuration Descriptor. */
-        const val CCCD_UUID = "00002902-0000-1000-8000-00805f9b34fb"
+        val CCCD_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     }
 
     private val tag = "GattServerCallback"
@@ -51,14 +52,14 @@ class GattServerCallback(
      * Long writes arrive as a series of prepared chunks that only take effect on
      * execute, keyed here by device address and characteristic uuid.
      */
-    private val preparedWrites = mutableMapOf<Pair<String, String>, ByteArrayOutputStream>()
+    private val preparedWrites = mutableMapOf<Pair<String, UUID>, ByteArrayOutputStream>()
 
     /** Sends a response to a central. Set by the manager that owns the server. */
     var sendResponse: (device: BluetoothDevice?, requestId: Int, status: Int, offset: Int, value: ByteArray?) -> Unit =
             { _, _, _, _, _ -> }
 
     /** The current value of a characteristic, used to answer read requests. */
-    var readCharacteristicValue: (uuid: String) -> ByteArray? = { null }
+    var readCharacteristicValue: (uuid: UUID) -> ByteArray? = { null }
 
     /** Called when a notification has been acknowledged, so the next may be sent. */
     var onNotificationSent: (device: BluetoothDevice) -> Unit = { }
@@ -116,7 +117,7 @@ class GattServerCallback(
         super.onCharacteristicReadRequest(device, requestId, offset, characteristic)
         Log.i(tag, "Read request from ${device?.address} for characteristic ${characteristic?.uuid}")
 
-        val uuid = characteristic?.uuid?.toString()
+        val uuid = characteristic?.uuid
         if (uuid == null) {
             sendResponse(device, requestId, BluetoothGatt.GATT_FAILURE, 0, null)
             return
@@ -145,8 +146,8 @@ class GattServerCallback(
 
         Log.i(tag, "Write request from ${device?.address} for characteristic ${characteristic?.uuid}")
 
-        val uuid = characteristic?.uuid?.toString()
-        if (device == null || uuid == null || !uuid.equals(rxCharacteristicUuid, ignoreCase = true)) {
+        val uuid = characteristic?.uuid
+        if (device == null || uuid == null || uuid != rxCharacteristicUuid) {
             Log.w(tag, "Write to unsupported characteristic: $uuid")
             if (responseNeeded) {
                 sendResponse(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
@@ -190,7 +191,7 @@ class GattServerCallback(
 
         // Report whether this central is subscribed, rather than the descriptor's
         // shared value, which is the same object for every central.
-        val isCccd = descriptor?.uuid?.toString().equals(CCCD_UUID, ignoreCase = true)
+        val isCccd = descriptor?.uuid == CCCD_UUID
         val value = if (isCccd && device != null && subscribedDevices.contains(device)) {
             BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
         } else if (isCccd) {
@@ -215,9 +216,8 @@ class GattServerCallback(
         super.onDescriptorWriteRequest(device, requestId, descriptor, preparedWrite, responseNeeded, offset, value)
         Log.i(tag, "Descriptor write request from ${device?.address} for descriptor ${descriptor?.uuid}")
 
-        val isCccd = descriptor?.uuid?.toString().equals(CCCD_UUID, ignoreCase = true)
-        val isTx = descriptor?.characteristic?.uuid?.toString()
-                .equals(txCharacteristicUuid, ignoreCase = true)
+        val isCccd = descriptor?.uuid == CCCD_UUID
+        val isTx = descriptor?.characteristic?.uuid == txCharacteristicUuid
 
         if (isCccd && isTx && device != null && value != null && value.isNotEmpty()) {
             // Bit 0 is notify, bit 1 is indicate. Either means this central

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/models/GattServiceRequest.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/models/GattServiceRequest.kt
@@ -1,5 +1,7 @@
 package dev.steenbakker.flutter_ble_peripheral.models
 
+import java.util.UUID
+
 /**
  * The GATT service Dart asked the peripheral to serve, with the characteristic
  * uuids it chose.
@@ -8,9 +10,13 @@ package dev.steenbakker.flutter_ble_peripheral.models
  * uuid, so that they stay the same across app launches and platforms. A central
  * caches the GATT database between connections, so a characteristic uuid that
  * moves breaks the link.
+ *
+ * They are parsed as they come off the channel, so a short form Dart sent is
+ * already expanded onto the Bluetooth Base UUID here, and everything downstream
+ * compares one canonical form against what Android reports on air.
  */
 data class GattServiceRequest(
-    val serviceUuid: String,
-    val txCharacteristicUuid: String,
-    val rxCharacteristicUuid: String,
+    val serviceUuid: UUID,
+    val txCharacteristicUuid: UUID,
+    val rxCharacteristicUuid: UUID,
 )

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/core/models/gatt_server_settings.dart
+++ b/lib/src/core/models/gatt_server_settings.dart
@@ -37,7 +37,9 @@ const String defaultRxCharacteristicUuid =
 /// a different layout.
 ///
 /// The uuids are the contract between the two sides of the link and must be
-/// stable, so they are never derived from the service uuid.
+/// stable, so they are never derived from the service uuid. The 16 bit
+/// (`'180d'`), 32 bit and 128 bit forms are all accepted, and a short one is
+/// expanded onto the Bluetooth Base UUID by the platform.
 @JsonSerializable()
 class GattServerSettings {
   /// Creates the settings for the GATT service to serve.


### PR DESCRIPTION
## Description

Someone asked whether they can advertise heart rate data (#161), which they can now, and
writing the answer showed that the uuids in it had to be spelled out in full for no good
reason. `readGattService` took the three GATT uuids straight off the channel and handed
them to `UUID.fromString`, so `'180d'` or `'2a37'` threw `IllegalArgumentException` while
the advertised uuids next to them went through `parseServiceUuid`, which takes the 16, 32
and 128 bit forms. `CBUUID` accepts the short forms on Apple and the Windows side already
routes all three through `ParseServiceUuid`, so Android was the only one out of line.

Creating the characteristic was not the whole problem either. `GattServerCallback` compared
uuid strings case-insensitively against what Dart sent, and Android reports the expanded
128 bit form on air, so a short uuid would have missed the RX write check and the CCCD
subscribe check even once the service existed — the server would have come up and then
ignored the central. Parsing at the boundary fixes both at once: `GattServiceRequest` holds
`UUID`s now, so there is one canonical form from the channel inwards, and the comparisons
are uuid equality rather than string matching.

While in there, `arguments["gattTxCharacteristicUuid"] as String ?: throw ...` never
reached its own message — `as` throws a `ClassCastException` on a missing key rather than
returning null, so the elvis was dead. It is `as?` now.

The example's lockfile is refreshed to 3.0.0 in the same commit, since it still pinned
2.1.1 and any `pub get` rewrote it.

Checked by building the example apk. There is no Android test target to add to, so the
short-form path is not covered by a test.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
