### PR TITLE
feat(android): start advertising without an activity attached

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,18 @@ already connected, the same as an Android advertise timeout does.
 ### Background advertising
 
 On Android the advertisement belongs to the process, so it keeps going while the app
-sits in the background and ends when the system kills the process. Advertising from a
-service rather than from an activity is not supported yet: `start()` needs an activity
-to check permissions against, and answers with a `No activity` error without one.
+sits in the background and ends when the system kills the process.
+
+`start()` also works from a foreground service, or any other engine with no activity
+attached, since advertising and the GATT server need none. What does need one is asking
+the user for something, and a service cannot ask: the permissions have to be granted
+already, by a screen that ran earlier, and `start()` answers
+`PeripheralBluetoothState.denied` rather than prompting when they are not. Bluetooth
+has to be on for the same reason — below Android 13 `enableBluetooth()` can still turn
+it on without asking, and above it that was removed, so from a service it answers
+`false`. `hasPermission()` and `requestPermission()` both report what is granted
+without an activity, but cannot tell a first refusal from a permanent one, since that
+distinction comes from the rationale check an activity provides.
 
 On iOS the advertisement ends with the foreground unless the app declares the
 `bluetooth-peripheral` background mode. With it, Core Bluetooth keeps advertising, but

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralManager.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralManager.kt
@@ -484,6 +484,22 @@ class FlutterBlePeripheralManager(
     }
 
     /**
+     * Attempts to enable Bluetooth without an activity to ask through.
+     *
+     * Only the programmatic path is available here, which Android 13 removed, so
+     * from a service on Tiramisu and above the adapter has to already be on.
+     *
+     * @return Whether Bluetooth is on now.
+     */
+    fun enableBluetooth(): Boolean {
+        if (isBluetoothEnabled()) return true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) return false
+        @Suppress("DEPRECATION")
+        mBluetoothManager?.adapter?.enable()
+        return isBluetoothEnabled()
+    }
+
+    /**
      * Attempts to enable Bluetooth on the device.
      *
      * If [callback] is not null, shows the system dialog to request user approval.
@@ -618,6 +634,40 @@ class FlutterBlePeripheralManager(
      * @param onReady Callback executed if Bluetooth is ready
      * @param onError Callback executed with the error [PeripheralBluetoothState]
      */
+    /**
+     * Ensures Bluetooth is ready without an activity to ask through, which is the
+     * position a foreground service or any other background isolate is in.
+     *
+     * Nothing can be asked for here: a service cannot show the permission dialog
+     * or the enable-Bluetooth dialog, so what is already granted and already on is
+     * all there is. Advertising and the GATT server themselves need no activity,
+     * so a service that was started from a screen which took care of permissions
+     * can serve on its own.
+     */
+    fun ensureBluetoothReady(
+        context: Context,
+        onReady: () -> Unit,
+        onError: (PeripheralBluetoothState) -> Unit
+    ) {
+        if (getBluetoothState() == PeripheralBluetoothState.Unsupported) {
+            onError(PeripheralBluetoothState.Unsupported)
+            return
+        }
+
+        if (!hasRequiredPermissions(context)) {
+            Log.w(TAG, "Cannot start without an activity unless the permissions are already granted")
+            onError(PeripheralBluetoothState.Denied)
+            return
+        }
+
+        if (!enableBluetooth()) {
+            onError(PeripheralBluetoothState.TurnedOff)
+            return
+        }
+
+        onReady()
+    }
+
     fun ensureBluetoothReady(
         activity: Activity,
         onReady: () -> Unit,

--- a/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/flutter_ble_peripheral/FlutterBlePeripheralPlugin.kt
@@ -204,21 +204,20 @@ class FlutterBlePeripheralPlugin :
         }
 
         val manager = flutterBlePeripheralManager!!
-
-        if (activityBinding == null) {
-            result.error("No activity", "Activity is not attached", null)
-            return
+        val onReady = { startPeripheral(call, result) }
+        val onError = { state: PeripheralBluetoothState ->
+            safeResult(result) { result.success(state.ordinal) }
         }
 
-        manager.ensureBluetoothReady(
-            activityBinding!!.activity,
-            onReady = {
-                startPeripheral(call, result)
-            },
-            onError = { state ->
-                safeResult(result) { result.success(state.ordinal) }
-            }
-        )
+        // Without an activity nothing can be asked of the user, but advertising
+        // and the GATT server do not need one, so a service whose permissions are
+        // already granted starts rather than being turned away.
+        val activity = activityBinding?.activity
+        if (activity == null) {
+            manager.ensureBluetoothReady(context!!, onReady, onError)
+        } else {
+            manager.ensureBluetoothReady(activity, onReady, onError)
+        }
     }
 
     /**
@@ -523,29 +522,30 @@ class FlutterBlePeripheralPlugin :
      * @param result Method channel result callback
      */
     private fun handleEnableBluetooth(call: MethodCall, result: MethodChannel.Result) {
-        if (activityBinding != null) {
-            val shouldAsk = call.arguments as Boolean
-            val isEnabled = flutterBlePeripheralManager!!.isBluetoothEnabled()
-            if (!isEnabled) {
-                if (shouldAsk) {
-                    flutterBlePeripheralManager!!.enableBluetooth(activityBinding!!.activity) { bluetoothEnabled ->
-                        safeResult(result) {
-                            result.success(bluetoothEnabled)
-                        }
-                    }
-                    return
-                } else {
-                    flutterBlePeripheralManager!!.enableBluetooth(activityBinding!!.activity, null)
-                }
+        if (activityBinding == null) {
+            // Nothing can be asked without an activity; below Tiramisu the adapter
+            // can still be turned on without asking.
+            safeResult(result) {
+                result.success(flutterBlePeripheralManager?.enableBluetooth() ?: false)
             }
+            return
+        }
 
-            safeResult(result) {
-                result.success(true)
+        val shouldAsk = call.arguments as Boolean
+        if (!flutterBlePeripheralManager!!.isBluetoothEnabled()) {
+            if (shouldAsk) {
+                flutterBlePeripheralManager!!.enableBluetooth(activityBinding!!.activity) { bluetoothEnabled ->
+                    safeResult(result) {
+                        result.success(bluetoothEnabled)
+                    }
+                }
+                return
             }
-        } else {
-            safeResult(result) {
-                result.error("No activity", "FlutterBlePeripheral is not correctly initialized", "null")
-            }
+            flutterBlePeripheralManager!!.enableBluetooth(activityBinding!!.activity, null)
+        }
+
+        safeResult(result) {
+            result.success(true)
         }
     }
 
@@ -553,7 +553,15 @@ class FlutterBlePeripheralPlugin :
      * Request runtime Bluetooth permissions.
      */
     private fun handleRequestPermission(result: MethodChannel.Result) {
-        val state = flutterBlePeripheralManager!!.requestPermission(activityBinding!!.activity) { state ->
+        val activity = activityBinding?.activity
+        if (activity == null) {
+            // A service cannot prompt, so the current state is the answer, which is
+            // what the Apple side does as well.
+            safeResult(result) { result.success(currentPermissionState().ordinal) }
+            return
+        }
+
+        val state = flutterBlePeripheralManager!!.requestPermission(activity) { state ->
             safeResult(result) {
                 result.success(state.ordinal)
             }
@@ -571,8 +579,14 @@ class FlutterBlePeripheralPlugin :
      * Check if Bluetooth permissions are granted.
      */
     private fun handleHasPermission(result: MethodChannel.Result) {
+        val activity = activityBinding?.activity
+        if (activity == null) {
+            safeResult(result) { result.success(currentPermissionState().ordinal) }
+            return
+        }
+
         val permission = flutterBlePeripheralManager!!
-            .requestPermission(activityBinding!!.activity, null)!!
+            .requestPermission(activity, null)!!
             .ordinal
         safeResult(result) {
             result.success(permission)
@@ -580,25 +594,57 @@ class FlutterBlePeripheralPlugin :
     }
 
     /**
+     * The permission state as far as it can be told without an activity.
+     *
+     * `getMissingPermissions` needs one for its rationale check, so from a service
+     * this is the granted-or-not answer, with no way to tell a first refusal from
+     * a permanent one.
+     */
+    private fun currentPermissionState(): PeripheralBluetoothState {
+        val manager = flutterBlePeripheralManager
+        val appContext = context
+        if (manager == null || appContext == null) return PeripheralBluetoothState.Unsupported
+        return if (manager.hasRequiredPermissions(appContext)) {
+            PeripheralBluetoothState.Granted
+        } else {
+            PeripheralBluetoothState.Denied
+        }
+    }
+
+    /**
      * Open system app settings for this application.
      */
     private fun handleOpenAppSettings(result: MethodChannel.Result) {
-        activityBinding!!.activity.startActivity(
-            Intent(
-                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                Uri.fromParts("package", context!!.packageName, null)
-            )
+        val intent = Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", context!!.packageName, null)
         )
+        startSettingsActivity(intent)
         safeResult(result) {
             result.success(null)
         }
     }
 
     /**
+     * Opens a settings page, from the activity where there is one.
+     *
+     * An intent started from the application context rather than an activity needs
+     * NEW_TASK, and Android throws instead of launching without it.
+     */
+    private fun startSettingsActivity(intent: Intent) {
+        val activity = activityBinding?.activity
+        if (activity != null) {
+            activity.startActivity(intent)
+            return
+        }
+        context?.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
+
+    /**
      * Open system Bluetooth settings.
      */
     private fun handleOpenBluetoothSettings(result: MethodChannel.Result) {
-        activityBinding!!.activity.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS), null)
+        startSettingsActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
         safeResult(result) {
             result.success(null)
         }


### PR DESCRIPTION
## Description

Running the plugin from a foreground service (#237) turned out to need almost nothing:
advertising and the GATT server never touched the activity, and the manager already holds
the application context. The only things that did are asking the user for a permission and
showing the enable-Bluetooth dialog, neither of which a service can do anyway, so
`handleStart` was turning away calls it could have served. It now takes an activity-free
path when none is attached: adapter supported, permissions already granted, adapter
already on, then straight into `startPeripheral`.

What a service cannot do stays impossible, and answers instead of crashing.
`start()` reports `denied` when the permissions are not granted rather than prompting for
them, and `turnedOff` when the adapter is off — below Android 13 `enableBluetooth()` can
still turn it on programmatically, and above it that was removed, so there it answers
false. `hasPermission()` and `requestPermission()` report what is granted from the
context, which cannot distinguish a first refusal from a permanent one, since that comes
from the rationale check an activity provides; that is the one thing that gets vaguer
without a screen.

Three `activityBinding!!` sites went with it: `hasPermission`, `requestPermission` and the
two settings shortcuts all threw an NPE from a service, which is the same crash #172 and
#208 were about, in the paths that fix did not reach. The settings intents now start from
the application context with `FLAG_ACTIVITY_NEW_TASK` when there is no activity, since
Android throws rather than launching without it. `handleEnableBluetooth` also lost a dead
`else` branch that could not be reached after the early return.

The README's background section said advertising from a service was not supported; it now
says what is and is not possible there instead.

Built the example apk. This one cannot be covered by a test or by CI — it needs a real
foreground service on a device, with the permissions granted beforehand — so it is
verified by compilation and by reading, and I would rather say so than imply otherwise.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [x] Documentation (`README.md`) was updated, if applicable.
