### PR TITLE
fix(windows): answer a read on a characteristic that does not notify

### DIFF
--- a/example/lib/interop_harness.dart
+++ b/example/lib/interop_harness.dart
@@ -43,6 +43,20 @@ const harnessComboUuidShort = 'ff01';
 /// [harnessComboUuidShort] as the platform reports it back.
 const harnessComboUuid = '0000ff01-0000-1000-8000-00805f9b34fb';
 
+/// A fourth characteristic, readable and nothing else.
+///
+/// The other three all notify, which on some platforms is what gets a read
+/// answered at all, so a characteristic that only reads is the one that proves
+/// a plain read is served on its own.
+const harnessReadOnlyUuidShort = 'ff02';
+
+/// [harnessReadOnlyUuidShort] as the platform reports it back.
+///
+/// Nothing seeds it: `sendData` only takes a characteristic that notifies, so
+/// what a read of it returns is the platform's own empty default. That a read
+/// is answered at all is the point of it.
+const harnessReadOnlyUuid = '0000ff02-0000-1000-8000-00805f9b34fb';
+
 void main() => runApp(const InteropHarnessApp());
 
 /// Names this platform the way the report does.
@@ -136,6 +150,10 @@ class _InteropHarnessAppState extends State<InteropHarnessApp> {
                 GattCharacteristicProperty.indicate,
               },
             ),
+            GattCharacteristic(
+              uuid: harnessReadOnlyUuidShort,
+              properties: {GattCharacteristicProperty.read},
+            ),
           ],
         ),
         androidSettings: const AndroidAdvertiseSettings(
@@ -149,6 +167,7 @@ class _InteropHarnessAppState extends State<InteropHarnessApp> {
         defaultTxCharacteristicUuid,
         defaultRxCharacteristicUuid,
         harnessComboUuid,
+        harnessReadOnlyUuid,
       ]);
 
       _record('READY', [platformName, harnessServiceUuid]);

--- a/windows/flutter_ble_peripheral_plugin.cpp
+++ b/windows/flutter_ble_peripheral_plugin.cpp
@@ -570,7 +570,7 @@ namespace flutter_ble_peripheral {
         std::vector<ServedCharacteristic> served;
         for (const auto& wanted : characteristics) {
             GattCharacteristicProperties properties = GattCharacteristicProperties::None;
-            if (wanted.properties & GattCharacteristicRequest::kRead) {
+            if (wanted.CanRead()) {
                 properties |= GattCharacteristicProperties::Read;
             }
             if (wanted.properties & GattCharacteristicRequest::kWrite) {
@@ -584,13 +584,6 @@ namespace flutter_ble_peripheral {
             }
             if (wanted.properties & GattCharacteristicRequest::kIndicate) {
                 properties |= GattCharacteristicProperties::Indicate;
-            }
-
-            // A characteristic that notifies is readable as well, so that a
-            // central which subscribes late can still pick up the payload sent
-            // last.
-            if (wanted.CanNotify()) {
-                properties |= GattCharacteristicProperties::Read;
             }
 
             GattLocalCharacteristicParameters parameters;
@@ -614,6 +607,7 @@ namespace flutter_ble_peripheral {
             entry.characteristic = result.Characteristic();
             entry.notifies = wanted.CanNotify();
             entry.writable = wanted.CanWrite();
+            entry.readable = wanted.CanRead();
             served.push_back(std::move(entry));
         }
 
@@ -627,9 +621,14 @@ namespace flutter_ble_peripheral {
             std::lock_guard<std::mutex> guard(gatt_characteristics_mutex_);
             gatt_characteristics_ = std::move(served);
             for (auto& entry : gatt_characteristics_) {
-                if (entry.notifies) {
+                // A read goes unanswered without a handler, and the central
+                // waits out its own timeout, so anything declared readable gets
+                // one whether or not it also notifies.
+                if (entry.readable) {
                     entry.read_token = entry.characteristic.ReadRequested(
                         { this, &FlutterBlePeripheralPlugin::OnReadRequested });
+                }
+                if (entry.notifies) {
                     entry.subscribers_token = entry.characteristic.SubscribedClientsChanged(
                         { this, &FlutterBlePeripheralPlugin::OnSubscribersChanged });
                 }

--- a/windows/flutter_ble_peripheral_plugin.h
+++ b/windows/flutter_ble_peripheral_plugin.h
@@ -100,6 +100,9 @@ namespace flutter_ble_peripheral {
             bool CanWrite() const {
                 return (properties & (kWrite | kWriteWithoutResponse)) != 0;
             }
+            // One that notifies is readable too, so a central which subscribes
+            // late can still pick up the payload sent last.
+            bool CanRead() const { return (properties & kRead) != 0 || CanNotify(); }
         };
 
         // A characteristic being served, with what it is subscribed to by and the
@@ -109,6 +112,7 @@ namespace flutter_ble_peripheral {
             GattLocalCharacteristic characteristic{ nullptr };
             bool notifies = false;
             bool writable = false;
+            bool readable = false;
             winrt::event_token read_token{};
             winrt::event_token write_token{};
             winrt::event_token subscribers_token{};


### PR DESCRIPTION
## Description

Registering `ReadRequested` was tied to whether a characteristic notifies, but the Read
property was granted to anything that asked for it. A characteristic declared with
`GattCharacteristicProperty.read` alone therefore went on air readable and then had no
handler to answer with, so every read of it went unanswered and the central sat there
until its own timeout. The subscription handler stays notify-only, since that is the one
that really is about notifying. `CanRead()` now carries the rule that a characteristic
which notifies is readable as well, instead of it being applied separately from the
handler that has to honour it.

The harness serves a fourth characteristic, `ff02`, readable and nothing else, so the
case has something standing on it. Nothing seeds it and a central reading it gets zero
bytes back: `sendData` only takes a characteristic that notifies, and on Windows it also
wants a subscriber, so there is no way to give a read-only characteristic a value at all.
That gap is left alone here — it is an API change across all three platforms rather than
part of this — and the check asserts only that the read is answered, which is what was
broken.

The central half is juliansteenbakker/flutter_ble_central#141. They have to land
together, since the central side counts the characteristics this one serves.

Run on hardware, both directions between an Android tablet and Windows: 35 passed, 0
failed, 2 skipped either way.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [x] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
